### PR TITLE
Fix LC76G GNSS driver: null-pointer call, dead decoders, dropped sentences

### DIFF
--- a/src/HAL/LC76G.cpp
+++ b/src/HAL/LC76G.cpp
@@ -39,13 +39,24 @@ void LC76G::processSentence(Sentence s) {
 
     for (auto it = _responses.begin(); it != _responses.end(); ++it) {
         uint16_t index = getCommand(it->commandId);
+        if (index == INVALID_COMMAND) continue;   // no table entry, nothing to match against
+
         if(COMMANDS[index].response) {  // <- check that response is valid before comparing it
             if (std::strncmp(s.data, COMMANDS[index].response, std::strlen(COMMANDS[index].response)) == 0) {
-                //decode the response
-                uint8_t buffer[5];
-                int numArgs;
-                if(COMMANDS[index].decode(s, numArgs, buffer)) {
-                    // Fire callback
+                // Decode the response. Both decode and callback are optional:
+                // several table entries pair a non-null `response` with a null
+                // `decode` (SAVE_TO_NVRAM, GET_NMEA_RATE), and sendCommand is
+                // called with a null callback in a few places. Calling either
+                // unconditionally branches to address 0.
+                uint8_t buffer[5] = {0};
+                int numArgs = 0;
+
+                bool decoded = true;
+                if (COMMANDS[index].decode) {
+                    decoded = COMMANDS[index].decode(s, numArgs, buffer);
+                }
+
+                if (decoded && it->callback) {
                     it->callback(numArgs, buffer, it->userContext);
                 }
 
@@ -359,6 +370,13 @@ void LC76G::sendCommand(CmdId cmdId, ResponseCallback cb = nullptr, void* userCt
     int length = 0;
 
     uint16_t index = getCommand(cmdId);
+    if (index == INVALID_COMMAND) {
+        if (ENABLE_GPS_DEBUG) {
+            Serial.print("[LC76G] unknown command id: ");
+            Serial.println((int)cmdId);
+        }
+        return;
+    }
 
     //call this command's build function
     length = COMMANDS[index].build(buffer,sizeof(buffer),COMMANDS[index].cmd,payload);

--- a/src/HAL/LC76G.cpp
+++ b/src/HAL/LC76G.cpp
@@ -387,12 +387,29 @@ void LC76G::sendCommand(CmdId cmdId, ResponseCallback cb = nullptr, void* userCt
     //call this command's build function
     length = COMMANDS[index].build(buffer,sizeof(buffer),COMMANDS[index].cmd,payload);
 
+    // snprintf returns the length it *would* have written, so a truncated
+    // build reports more than the buffer holds. Checksumming that length
+    // would read past the end of `buffer`.
+    if (length < 0 || (size_t)length >= sizeof(buffer)) {
+        if (ENABLE_GPS_DEBUG) {
+            Serial.println("[LC76G] command body too long, dropped");
+        }
+        return;
+    }
+
     // Compute checksum over the command body only (no '$', '*', or CRLF)
     uint8_t checksum = calculate_xor_checksum(reinterpret_cast<const uint8_t*>(buffer), length);
 
-    // Format full NMEA sentence
-    char buffer2[64];  // allow for body + framing
-    length = sprintf(buffer2, "$%s*%02X\r\n", buffer, checksum);
+    // Format full NMEA sentence. Sized for the largest body plus the six
+    // framing characters ('$', '*', two hex digits, CR, LF) and a NUL.
+    char buffer2[sizeof(buffer) + 8];
+    length = snprintf(buffer2, sizeof(buffer2), "$%s*%02X\r\n", buffer, checksum);
+    if (length < 0 || (size_t)length >= sizeof(buffer2)) {
+        if (ENABLE_GPS_DEBUG) {
+            Serial.println("[LC76G] framed sentence too long, dropped");
+        }
+        return;
+    }
 
     queueCommand(reinterpret_cast<const uint8_t*>(buffer2), length);
 

--- a/src/HAL/LC76G.cpp
+++ b/src/HAL/LC76G.cpp
@@ -139,7 +139,8 @@ LC76G::State LC76G::stateMachine() {
             if (_mode == MODE_RECEIVE) {
                 if (length == 0) {
                     _state=STATE_IDLE;
-                    return _state;
+                    break;      // break, not return: the _stateEntry bookkeeping
+                                // at the bottom of this function must still run
                 }
                 // Limit to max read size
                 _transactionLength = min(length, (uint16_t)MAX_BUFFER);
@@ -147,7 +148,7 @@ LC76G::State LC76G::stateMachine() {
                 // MODE_TRANSMIT - check buffer size
                 if (_txLength > length) {
                     _state=STATE_ERROR;
-                    return _state;
+                    break;
                 }
                 _transactionLength = _txLength;
             }
@@ -207,7 +208,12 @@ LC76G::State LC76G::stateMachine() {
         break;
     
     case STATE_PROCESS_RECEIVE:
-        _CR = false;
+        // _CR is deliberately NOT reset here. Reads are capped at MAX_BUFFER
+        // (64) bytes and NMEA sentences routinely exceed that, so a sentence
+        // whose '\r' lands at the end of one read and '\n' at the start of the
+        // next must carry the flag across. Clearing it here dropped every
+        // sentence that straddled a read boundary -- GSV worst of all. The
+        // per-character else-branch below already maintains it correctly.
         for(int i=0; i<_transactionLength;i++){
             if (_rxBuffer[i] == '$') _$found = true;             // check for '$'
             if(_$found) {

--- a/src/HAL/LC76G.hpp
+++ b/src/HAL/LC76G.hpp
@@ -297,11 +297,17 @@ class LC76G
     void pollResponseTimeouts();
     void processSentence(Sentence s);
 
-    uint16_t getCommand(CmdId cmdId) {
+    // Returned by getCommand() when a CmdId has no table entry. Callers must
+    // check for it: returning 0 on a miss would silently resolve to
+    // COMMANDS[0], which is PAIR_LOW_POWER_ENTRY_RTC_MODE -- i.e. an unknown
+    // command would put the receiver to sleep.
+    static const uint16_t INVALID_COMMAND = 0xFFFF;
+
+    uint16_t getCommand(CmdId cmdId) const {
         for (uint16_t i =0; i< std::size(COMMANDS); ++i) {
             if ( COMMANDS[i].cmdId == cmdId) return i;
         }
-        return 0;
+        return INVALID_COMMAND;
     }
 };
 

--- a/src/HAL/LC76G.hpp
+++ b/src/HAL/LC76G.hpp
@@ -58,22 +58,40 @@ class LC76G
         return true; 
     }
 
+    // Acknowledgement of the form "$PAIR001,<cmd>,<result>*CS" -- the value we
+    // want is the third field. Skips the talker and the echoed command id.
+    // Scans into unsigned int rather than using the %hh length modifier, which
+    // newlib-nano's reduced scanf does not reliably support.
     static bool decode_1u8(Sentence response, int& numArgs, void* payload) {
         uint8_t* byte_array = (uint8_t*)payload;
-        numArgs = sscanf(response.data,"%*[^,],%c*%*X",&byte_array[0]);
-	    return numArgs==2;
+        unsigned int a = 0;
+        numArgs = sscanf(response.data,"%*[^,],%*[^,],%u",&a);
+        if (numArgs != 1) return false;
+        byte_array[0] = (uint8_t)a;
+        return true;
     }
 
+    // Query reply of the form "$PAIR063,<type>,<rate>*CS" -- two numeric fields
+    // after the talker.
     static bool decode_2u8(Sentence response, int& numArgs, void* payload) {
         uint8_t* byte_array = (uint8_t*)payload;
-        numArgs = sscanf(response.data,"%*[^,],%c,%c*%*X",&byte_array[0],&byte_array[1]);
-	    return numArgs==2;
+        unsigned int a = 0, b = 0;
+        numArgs = sscanf(response.data,"%*[^,],%u,%u",&a,&b);
+        if (numArgs != 2) return false;
+        byte_array[0] = (uint8_t)a;
+        byte_array[1] = (uint8_t)b;
+        return true;
     }
 
+    // %[^,] rather than %s: the fields are comma-separated, and %s would run
+    // past the delimiter and swallow the rest of the sentence.
     static bool decode_1char_1u8(Sentence response, int& numArgs, void* payload) {
       Payload1Ch1U8* p = (Payload1Ch1U8*)payload;
-      numArgs = sscanf(response.data, "%*[^,],%9s,%hhu*%*X", p->a, &p->b);
-	    return numArgs==2;
+      unsigned int b = 0;
+      numArgs = sscanf(response.data, "%*[^,],%9[^,],%u", p->a, &b);
+      if (numArgs != 2) return false;
+      p->b = (uint8_t)b;
+      return true;
     }
 
 


### PR DESCRIPTION
Addresses **C2, H12, H13, H15, M16** from #3. All five are in `src/HAL/LC76G.*`, which is why they are grouped — they touch overlapping lines and would conflict as separate branches. One commit each.

> Depends on #4. The project does not build without that PR's `platformio.ini` fix, so I verified these by temporarily borrowing the corrected file. It is **not** included in this branch's diff.

## C2 — null function pointer call (crash, user-reachable)

`processSentence` checked `response` for null, then called `decode` and `callback` unconditionally. Two table entries pair a non-null `response` with a **null `decode`**:

```cpp
{SAVE_TO_NVRAM,  "PAIR511", &build_no_args, "PAIR001,511,1",      nullptr, 10000}
{GET_NMEA_RATE,  "PQTMCFGMSGRATE,R", ...,   "$PQTMCFGMSGRATE,OK", nullptr, 10000}
```

`SAVE_TO_NVRAM` is reachable from the UI — the GPS screen's *Save NVRAM* item → `AppEventType::saveGPSNVRAM` → `HAL::gpsSaveNVRAM()`, which **also** passes a null callback. Both pointers null on the same path. Four button presses from a hard fault.

`pollResponseTimeouts` already guarded its callback; this brings the matching path in line.

## H13 — `getCommand` fell back to "sleep"

Returned `0` on a lookup miss. Index 0 is `PAIR_LOW_POWER_ENTRY_RTC_MODE`, so an unrecognised `CmdId` would put the receiver into low-power RTC mode. Now returns `INVALID_COMMAND` and both call sites check. The table is currently complete, so this is a trap for the next enumerator added without a row rather than a live bug.

## H12 — decoders that could never succeed

```cpp
numArgs = sscanf(response.data,"%*[^,],%c*%*X",&byte_array[0]);
return numArgs==2;      // one conversion requested; cannot return 2
```

Always reported failure, and `processSentence` discards the pending response either way — so acknowledgements for `SET_NMEA_MSG_RATE` were silently dropped. That is the command `App::update`'s startup NMEA configuration sequence depends on.

`%c` also stores the raw character rather than parsing a number, so a rate of `0` decoded as ASCII 48.

Corrected to the real sentence shapes (`"$PAIR001,<cmd>,<result>"`, `"$PAIR063,<type>,<rate>"`). All three decoders now scan into `unsigned int` and narrow explicitly rather than relying on `%hh`, which newlib-nano's reduced `scanf` does not reliably support.

## H15 — sentences straddling a read boundary were discarded

```cpp
case STATE_PROCESS_RECEIVE:
    _CR = false;          // <-- discards cross-read state
```

`_CR` is a member precisely so it can carry across reads. Reads cap at `MAX_BUFFER` (64) bytes while NMEA sentences routinely exceed that, so any sentence with `\r` at the end of one read and `\n` at the start of the next was dropped. Longer sentences suffer disproportionately — GSV most of all.

Also changed two `return _state` early exits in `STATE_STEP1B_READ` to `break`, so the `_stateEntry` bookkeeping at the end of the function still runs; otherwise the `i2c_DELAY` guard for the next state could elapse immediately.

## M16 — framing buffer overflow

`sprintf` framed a 64-byte body into a 64-byte buffer; the framing adds 6 chars plus NUL. Latent today, one longer PQTMCFG command from being real. `buffer2` is now sized from `buffer` rather than a hand-synced literal, uses `snprintf`, and the `build()` result is validated first — `snprintf` returns the length it *would* have written, and that value was being handed to `calculate_xor_checksum`, which would read past the end of `buffer`.

## Verification

`pio run` clean after each commit; no new warnings under `-Wall -Wextra`. Flash 420148 → 420244 bytes (+96).

**Not flashed to hardware.** C2 and H13 are reasoned from the command table and are unambiguous. H12 and H15 change runtime behaviour in ways worth confirming on-device: with `DEBUG_GPS 1`, H15 should show GSV sentences appearing in `/gpsLog.txt` that previously never arrived, and H12 should show `SET_NMEA_MSG_RATE` acknowledgements firing their callback instead of timing out after 90 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)