### PR TITLE
BLE: bounds-check untrusted payloads, fix CPS parsing, correct rate arithmetic

### DIFF
--- a/src/HAL/Bluetooth/BT_Device.hpp
+++ b/src/HAL/Bluetooth/BT_Device.hpp
@@ -48,11 +48,14 @@ class BT_Device {
     
     MacAddress MAC;
     uint8_t u8_Batt = 100;
-    bool _begun;
-    uint16_t _conn_handle;
-    E_Type_BT_Device bt_type;
+    // Derived devices are heap-allocated, so these need explicit initialisers.
+    // _disconnected in particular is read as a condition in csc::csc_notify
+    // before anything assigns it.
+    bool _begun = false;
+    uint16_t _conn_handle = BLE_CONN_HANDLE_INVALID;
+    E_Type_BT_Device bt_type = E_Type_BT_Device::bt_csc;
     static std::vector<std::unique_ptr<BT_Device>> btDevices;
-    bool _disconnected;
+    bool _disconnected = false;
 
     BT_Device(){};
     virtual void removeFromLocalList() {};

--- a/src/HAL/Bluetooth/BluetoothSystem.cpp
+++ b/src/HAL/Bluetooth/BluetoothSystem.cpp
@@ -122,9 +122,14 @@ void BluetoothSystem::scan_callback(ble_gap_evt_adv_report_t* report) {
 
 void BluetoothSystem::scan_discovery(ble_gap_evt_adv_report_t* report) {
     BluetoothDevice newDevice(report->peer_addr.addr);
-    memset(&newDevice.name,0,32);
+    memset(newDevice.name, 0, sizeof(newDevice.name));
 
-    Bluefruit.Scanner.parseReportByType(report, BLE_GAP_AD_TYPE_COMPLETE_LOCAL_NAME, (uint8_t*)newDevice.name, sizeof(newDevice.name));
+    // Leave room for a terminator: parseReportByType fills up to the length
+    // given and does not NUL-terminate, so a name of exactly sizeof(name)
+    // characters would leave the buffer unterminated for the Serial.println
+    // and String conversion below.
+    Bluefruit.Scanner.parseReportByType(report, BLE_GAP_AD_TYPE_COMPLETE_LOCAL_NAME,
+                                        (uint8_t*)newDevice.name, sizeof(newDevice.name) - 1);
 
     bool bMatch = false;
     //check if the list contains anything
@@ -246,8 +251,12 @@ void BluetoothSystem::loadDevices() {
 
             BluetoothDevice newDevice(MAC);
 
-            device["name"].as<String>().toCharArray(newDevice.name, device["name"].as<String>().length() + 1);
-            
+            // Size argument must be the DESTINATION capacity, not the source
+            // length -- newDevice.name is char[32] and this string comes from
+            // a user-editable file on the SD card. toCharArray truncates and
+            // NUL-terminates when given the real capacity.
+            device["name"].as<String>().toCharArray(newDevice.name, sizeof(newDevice.name));
+
             newDevice.type = device["type"];
             newDevice.saved = true;
 

--- a/src/HAL/Bluetooth/cps.cpp
+++ b/src/HAL/Bluetooth/cps.cpp
@@ -71,58 +71,97 @@ bool cps::discovered() {
 }
 
 void cps::cps_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) {
-  //https://github.com/oesmith/gatt-xml/blob/master/org.bluetooth.service.cycling_power.xml
+  (void)chr;
+  // Cycling Power Measurement (0x2A63):
+  //
+  //   uint16  flags
+  //   sint16  instantaneous power (watts)
+  //   ... optional fields, in ascending flag-bit order
+  //
+  // The flags field is 16-bit and power starts at offset 2. The previous
+  // implementation followed the CSC layout instead -- 8-bit flags, power at
+  // offset 1 -- so power straddled the flags high byte and the power low byte,
+  // and every optional field after it was shifted by one. The flag bits were
+  // also misassigned: bit 1 is the balance *reference*, not cadence-present,
+  // and cadence has to be derived from the crank revolution pair on bit 5.
 
-  uint16_t power;
-  uint16_t cadence = 0;
-  int16_t torque = 0;
-  int16_t pedal_balance = 0;
-  int16_t force_magnitude = 0;
-  uint8_t offset = 1;
+  if (len < 4) return;                          // flags + power are mandatory
 
-  _CadencePresent = false;
-  _TorquePresent = false;
-  _BalancePresent = false;
+  const uint16_t flags = (uint16_t)data[0] | ((uint16_t)data[1] << 8);
+
+  int16_t power;
+  memcpy(&power, data + 2, 2);
+  uint16_t offset = 4;
+
+  _BalancePresent  = false;
+  _TorquePresent   = false;
+  _CadencePresent  = false;
   _ForceMagPresent = false;
 
-  memcpy(&power, data + offset, 2);
-  offset += 2;
-  
-  if (data[0] & 0x02) {
-    memcpy(&cadence, data + offset, 2);
-    _CadencePresent = true;
-    offset += 2;
+  if (flags & CPS_FLAG_PEDAL_BALANCE_PRESENT) {
+    if (len < offset + 1u) return;
+    f32_pedal_balance = static_cast<float>(data[offset]) * 0.5f;   // 1/2 %
+    _BalancePresent = true;
+    offset += 1;
   }
-  
-  if (data[0] & 0x04) {
+
+  if (flags & CPS_FLAG_ACCUM_TORQUE_PRESENT) {
+    if (len < offset + 2u) return;
+    uint16_t torque;
     memcpy(&torque, data + offset, 2);
+    f32_torque = static_cast<float>(torque) / 32.0f;               // 1/32 Nm
     _TorquePresent = true;
     offset += 2;
   }
-  
-  if (data[0] & 0x08) {
-    memcpy(&pedal_balance, data + offset, 2);
-    _BalancePresent = true;
-    offset += 2;
+
+  if (flags & CPS_FLAG_WHEEL_REV_PRESENT) {
+    if (len < offset + 6u) return;
+    offset += 6;   // uint32 cumulative + uint16 event time; speed comes from CSC
   }
-  
-  if (data[0] & 0x10) {
-    memcpy(&force_magnitude, data + offset, 2);
+
+  if (flags & CPS_FLAG_CRANK_REV_PRESENT) {
+    if (len < offset + 4u) return;
+    uint16_t revs, evt;
+    memcpy(&revs, data + offset, 2);
+    memcpy(&evt,  data + offset + 2, 2);
+    offset += 4;
+
+    // Cadence is a rate, not a transmitted value: revolutions per minute from
+    // the change in cumulative revolutions over the change in event time,
+    // which is expressed in 1/1024 s. Both counters are free-running uint16,
+    // so plain unsigned subtraction handles wraparound.
+    if (_hasCrankData) {
+      uint16_t dRev = (uint16_t)(revs - u16_CrankRevs_Prev);
+      uint16_t dEvt = (uint16_t)(evt  - u16_CrankEvt_Prev);
+      if (dEvt > 0) {
+        f32_cadence = 60.0f * 1024.0f * (float)dRev / (float)dEvt;
+        _CadencePresent = true;
+      }
+    }
+    u16_CrankRevs_Prev = revs;
+    u16_CrankEvt_Prev  = evt;
+    _hasCrankData = true;
+  }
+
+  if (flags & CPS_FLAG_EXTREME_FORCE_PRESENT) {
+    if (len < offset + 4u) return;
+    int16_t maxForce;
+    memcpy(&maxForce, data + offset, 2);
+    f32_force_magnitude = static_cast<float>(maxForce);            // newtons
     _ForceMagPresent = true;
-    offset += 2;
+    offset += 4;   // max and min
   }
-  
+
   f32_power = static_cast<float>(power);
-  f32_cadence = static_cast<float>(cadence);
-  f32_torque = static_cast<float>(torque) / 32.0; // Convert to Nm
-  f32_pedal_balance = static_cast<float>(pedal_balance) / 100.0; // Convert to %
-  f32_force_magnitude = static_cast<float>(force_magnitude) / 10.0; // Convert to Nm
-  
-  Serial.print("Power: "); Serial.println(f32_power);
-  Serial.print("Cadence: "); Serial.println(f32_cadence);
-  Serial.print("Torque: "); Serial.println(f32_torque);
-  Serial.print("Pedal Balance: "); Serial.println(f32_pedal_balance);
-  Serial.print("Force Magnitude: "); Serial.println(f32_force_magnitude);
+  _hasData = true;
+
+  if (ENABLE_BLUETOOTH_DEBUG) {
+    Serial.print("[CPS] power "); Serial.print(f32_power);
+    Serial.print(" W, cadence "); Serial.print(f32_cadence);
+    Serial.print(" rpm, torque "); Serial.print(f32_torque);
+    Serial.print(" Nm, balance "); Serial.print(f32_pedal_balance);
+    Serial.println(" %");
+  }
 }
 
 data_record cps::getPower() {

--- a/src/HAL/Bluetooth/cps.cpp
+++ b/src/HAL/Bluetooth/cps.cpp
@@ -165,69 +165,84 @@ void cps::cps_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
 }
 
 data_record cps::getPower() {
+  // Only report devices that have actually delivered a measurement. Without
+  // the hasData() guard this reported f32_power for a device created at boot
+  // from devices.txt but not yet connected.
   data_record power = {0, false};
+  uint16_t contributors = 0;
   for (cps* dev : _cpsDevices) {
-    power.value += dev->f32_power;
-    power.live = true;
+    if (dev->hasData()) {
+      power.value += dev->f32_power;
+      power.live = true;
+      contributors++;
+    }
   }
-  if (_cpsDevices.size() > 0) {
-    power.value /= _cpsDevices.size();
+  if (contributors > 0) {
+    power.value /= contributors;
   }
   return power;
 }
 
 data_record cps::getCadence() {
   data_record cadences = {0, false};
+  uint16_t contributors = 0;
   for (cps* dev : _cpsDevices) {
     if(dev->_CadencePresent) {
       cadences.value += dev->f32_cadence;
       cadences.live = true;
+      contributors++;
     }
   }
-  if (_cpsDevices.size() > 0) {
-    cadences.value /= _cpsDevices.size();
+  if (contributors > 0) {
+    cadences.value /= contributors;
   }
   return cadences;
 }
 
 data_record cps::getTorque() {
   data_record torque_values = {0, false};
+  uint16_t contributors = 0;
   for (cps* dev : _cpsDevices) {
     if(dev->_TorquePresent) {
       torque_values.value += dev->f32_torque;
       torque_values.live = true;
+      contributors++;
     }
   }
-  if (_cpsDevices.size() > 0) {
-    torque_values.value /= _cpsDevices.size();
+  if (contributors > 0) {
+    torque_values.value /= contributors;
   }
   return torque_values;
 }
 
 data_record cps::getPedalBalance() {
   data_record pedal_balance_values = {0, false};
+  uint16_t contributors = 0;
   for (cps* dev : _cpsDevices) {
     if(dev->_BalancePresent) {
       pedal_balance_values.value += dev->f32_pedal_balance;
       pedal_balance_values.live = true;
+      contributors++;
     }
   }
-  if (_cpsDevices.size() > 0) {
-    pedal_balance_values.value /= _cpsDevices.size();
+  if (contributors > 0) {
+    pedal_balance_values.value /= contributors;
   }
   return pedal_balance_values;
 }
 
 data_record cps::getForceMagnitude() {
   data_record force_magnitude_values = {0, false};
+  uint16_t contributors = 0;
   for (cps* dev : _cpsDevices) {
     if(dev->_ForceMagPresent) {
       force_magnitude_values.value += dev->f32_force_magnitude;
       force_magnitude_values.live = true;
+      contributors++;
     }
   }
-  if (_cpsDevices.size() > 0) {
-    force_magnitude_values.value /= _cpsDevices.size();
+  if (contributors > 0) {
+    force_magnitude_values.value /= contributors;
   }
   return force_magnitude_values;
 }

--- a/src/HAL/Bluetooth/cps.hpp
+++ b/src/HAL/Bluetooth/cps.hpp
@@ -26,9 +26,21 @@ class cps : public BT_Device {
 
     static std::vector<cps*> _cpsDevices;
 
-    bool _CadencePresent, _TorquePresent, _BalancePresent, _ForceMagPresent;
-    uint16_t u16_feature;
-    uint8_t u8_location;
+    // In-class initialisers: cps objects are heap-allocated via `new cps(MAC)`,
+    // so unlike the HAL/App singletons they get no static zero-init. getPower()
+    // is called from HAL::update() on every main-loop iteration starting at
+    // BOOT -- before any notification has arrived -- so these must not be
+    // indeterminate.
+    bool _CadencePresent = false;
+    bool _TorquePresent = false;
+    bool _BalancePresent = false;
+    bool _ForceMagPresent = false;
+    bool _hasData = false;          // set once a measurement has been decoded
+    bool _hasCrankData = false;     // set once a crank revolution pair is known
+    uint16_t u16_feature = 0;
+    uint8_t u8_location = 0;
+    uint16_t u16_CrankRevs_Prev = 0;
+    uint16_t u16_CrankEvt_Prev = 0;
 
     cps(){
       this->bt_type = E_Type_BT_Device::bt_cps;
@@ -49,7 +61,16 @@ class cps : public BT_Device {
     }
 
   public:
-    float f32_power, f32_cadence, f32_torque, f32_pedal_balance, f32_force_magnitude;
+    float f32_power = 0.0f;
+    float f32_cadence = 0.0f;
+    float f32_torque = 0.0f;
+    float f32_pedal_balance = 0.0f;
+    float f32_force_magnitude = 0.0f;
+
+    // True once at least one measurement notification has been decoded.
+    // getPower() must not report a reading before this.
+    bool hasData() const { return _hasData; }
+
     virtual ~cps(){};
     
     static void create_cps(MacAddress MAC)

--- a/src/HAL/Bluetooth/cps.hpp
+++ b/src/HAL/Bluetooth/cps.hpp
@@ -9,12 +9,24 @@
 #include "BT_Device.hpp"
 #include "HAL/SensorData.hpp"
 
-// Cycling Speed and Cadence configuration
+// Cycling Power configuration
 #define     GATT_CPS_UUID                           0x1818
 #define     GATT_CPS_MEASUREMENT_UUID               0x2A63
 #define     GATT_CPS_VECTOR_UUID                    0x2A64
 #define     GATT_CPS_FEATURE_UUID                   0x2A65
 #define     GATT_CPS_CONTROL_POINT_UUID             0x2A66
+
+/* Cycling Power Measurement flags (uint16, little endian).
+ * Note this field is 16-bit, unlike the 8-bit flags in CSC Measurement --
+ * the two characteristics do not share a layout. */
+#define     CPS_FLAG_PEDAL_BALANCE_PRESENT          0x0001  // uint8,  1/2 %
+#define     CPS_FLAG_PEDAL_BALANCE_REFERENCE        0x0002  // no data
+#define     CPS_FLAG_ACCUM_TORQUE_PRESENT           0x0004  // uint16, 1/32 Nm
+#define     CPS_FLAG_ACCUM_TORQUE_SOURCE            0x0008  // no data
+#define     CPS_FLAG_WHEEL_REV_PRESENT              0x0010  // uint32 + uint16
+#define     CPS_FLAG_CRANK_REV_PRESENT              0x0020  // uint16 + uint16
+#define     CPS_FLAG_EXTREME_FORCE_PRESENT          0x0040  // sint16 + sint16
+#define     CPS_FLAG_EXTREME_TORQUE_PRESENT         0x0080  // sint16 + sint16
 
 class cps : public BT_Device {
 

--- a/src/HAL/Bluetooth/csc.cpp
+++ b/src/HAL/Bluetooth/csc.cpp
@@ -200,29 +200,36 @@ void csc::csc_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
 }
 
 data_record csc::getSpeed() {
+  // Average over the devices that actually contribute, not over every CSC
+  // device present. Dividing by _cscDevices.size() halved the reading when
+  // one of two sensors reported cadence only.
   data_record speed = {0, false};
+  uint16_t contributors = 0;
   for (csc* dev : _cscDevices) {
     if(dev->b_speed_present) {
       speed.value += dev->f32_wheel_rpm;
       speed.live = true;
+      contributors++;
     }
   }
-  if (_cscDevices.size() > 0) {
-    speed.value /= _cscDevices.size();
+  if (contributors > 0) {
+    speed.value /= contributors;
   }
   return speed;
 }
 
 data_record csc::getCadence() {
   data_record cadence = {0, false};
+  uint16_t contributors = 0;
   for (csc* dev : _cscDevices) {
     if(dev->b_cadence_present) {
       cadence.value += dev->f32_cadence;
       cadence.live = true;
+      contributors++;
     }
   }
-  if (_cscDevices.size() > 0) {
-    cadence.value /= _cscDevices.size();
+  if (contributors > 0) {
+    cadence.value /= contributors;
   }
   return cadence;
 }

--- a/src/HAL/Bluetooth/csc.cpp
+++ b/src/HAL/Bluetooth/csc.cpp
@@ -120,7 +120,13 @@ void csc::csc_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
   uint32_t u32_WheelCount;
   uint16_t u16_SpeedEvt, u16_CrankCount, u16_CrankEvt;
 
+  // The payload comes from the remote sensor, so every field must be bounds
+  // checked against len before it is read. A short or malformed notification
+  // previously read past the end of the buffer.
+  if (len < 1) return;
+
   if ((data[0] & 0x01) ==1) {
+    if (len < offset + 6u) return;      // uint32 revolutions + uint16 event time
     memcpy(&u32_WheelCount, data+offset, 4);
     offset += 4;
     memcpy(&u16_SpeedEvt, data+offset, 2);
@@ -167,6 +173,7 @@ void csc::csc_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
     }
   }
   if ((data[0] & 0x02) == 2) {
+    if (len < offset + 4u) return;      // uint16 revolutions + uint16 event time
     memcpy(&u16_CrankCount, data+offset, 2);
     offset += 2;
     memcpy(&u16_CrankEvt, data+offset, 2);

--- a/src/HAL/Bluetooth/csc.cpp
+++ b/src/HAL/Bluetooth/csc.cpp
@@ -141,24 +141,16 @@ void csc::csc_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
   
     //check for overflow of speed evt
     if (u16_SpeedEvt != u16_SpeedEvt_Prev) {
-      u16_speed_delta = 0;
-      if (u16_SpeedEvt>u16_SpeedEvt_Prev) {
-        u16_speed_delta = u16_SpeedEvt - u16_SpeedEvt_Prev;
-      } else {
-        u16_speed_delta = u16_SpeedEvt + (65535 - u16_SpeedEvt_Prev);
-      }
+      // Free-running uint16 counter: plain unsigned subtraction already wraps
+      // correctly, and does so without the off-by-one of (65535 - prev).
+      u16_speed_delta = (uint16_t)(u16_SpeedEvt - u16_SpeedEvt_Prev);
       u16_SpeedEvt_Prev = u16_SpeedEvt;
       millis_at_spd_evt = millis();
       exp_next_spd_evt = millis_at_spd_evt + uint(u16_speed_delta*0.9765625); //convert 1/1024ths of a second into milliseconds
     }
 
-     //check for overflow of speed count
-    u32_WheelCount_delta=0;
-    if (u32_WheelCount >= u32_WheelCount_Prev) {
-      u32_WheelCount_delta = u32_WheelCount-u32_WheelCount_Prev;
-    } else if(u32_WheelCount_Prev>u32_WheelCount) {
-      u32_WheelCount_delta = u32_WheelCount + (4294967295 - u32_WheelCount_Prev);
-    }
+    //free-running uint32 counter, wraps correctly under subtraction
+    u32_WheelCount_delta = (uint32_t)(u32_WheelCount - u32_WheelCount_Prev);
     u32_WheelCount_Prev = u32_WheelCount;
 
     //calculate the rate of change and convert to km/h
@@ -169,7 +161,7 @@ void csc::csc_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
 
       //csc time delta is in 1/1024ths of a second
       //
-      raw_wheel_rpm = 61140.0 * float(u32_WheelCount_delta)/float(u16_speed_delta);
+      raw_wheel_rpm = 61440.0 * float(u32_WheelCount_delta)/float(u16_speed_delta);
     }
   }
   if ((data[0] & 0x02) == 2) {
@@ -188,31 +180,21 @@ void csc::csc_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
 
     //check for overflow of crank evt
     if (u16_CrankEvt != u16_CrankEvt_Prev) {
-      u16_crank_delta = 0;
-      if (u16_CrankEvt>u16_CrankEvt_Prev) {
-        u16_crank_delta = u16_CrankEvt - u16_CrankEvt_Prev;
-      } else {
-        u16_crank_delta = u16_CrankEvt + (65535 - u16_CrankEvt_Prev);
-      }
+      u16_crank_delta = (uint16_t)(u16_CrankEvt - u16_CrankEvt_Prev);
       millis_at_cad_evt = millis();
       exp_next_cad_evt = millis_at_cad_evt + uint(u16_crank_delta*0.9765625); //convert 1/1024ths of a second into milliseconds
       u16_CrankEvt_Prev = u16_CrankEvt;
     }
 
-    //check for overflow of crank count
-    u16_CrankCount_delta = 0;
-    if (u16_CrankCount>u16_CrankCount_Prev) {
-      u16_CrankCount_delta = u16_CrankCount - u16_CrankCount_Prev;
-    } else if(u16_CrankCount_Prev>u16_CrankCount) {
-      u16_CrankCount_delta = u16_CrankCount + (65535 - u16_CrankCount_Prev);
-    }
+    //free-running uint16 counter, wraps correctly under subtraction
+    u16_CrankCount_delta = (uint16_t)(u16_CrankCount - u16_CrankCount_Prev);
     u16_CrankCount_Prev = u16_CrankCount;
     
     //calculate rate of change and convert to rpm
     f32_cadence_raw = 0;
     if (u16_crank_delta>0) {
-      //61140 is 60*1024, so this is converting the crank delta and time delta into revolutions per minute
-      f32_cadence_raw = 61140.0 *float(u16_CrankCount_delta)/float(u16_crank_delta);
+      //61440 is 60*1024: converts the crank delta and 1/1024s time delta into revolutions per minute
+      f32_cadence_raw = 61440.0 *float(u16_CrankCount_delta)/float(u16_crank_delta);
     }
   }
 }
@@ -262,9 +244,9 @@ void csc::update(uint32_t now) {
   //use the last known u16_CrankCount_delta delta and an adjusted time delta to come up with an actual cadance estimate
   if (now>exp_next_cad_evt) {
     uint32_t diff = now - exp_next_cad_evt;
-    uint32_t delta_adjusted = u16_crank_delta + diff * 0.9765625; //convert milliseconds into 1/1024ths of a second
+    uint32_t delta_adjusted = u16_crank_delta + diff * 1.024f; //convert milliseconds into 1/1024ths of a second (1024/1000)
     if ( delta_adjusted > 0)
-      f32_cad_est = 61140.0 *float(u16_CrankCount_delta)/float(delta_adjusted);
+      f32_cad_est = 61440.0 *float(u16_CrankCount_delta)/float(delta_adjusted);
   }else{
     f32_cad_est = f32_cadence_raw;
   }
@@ -275,9 +257,9 @@ void csc::update(uint32_t now) {
   //use the last known wheelcount delta and an adjusted time delta to come up with an actual speed estimate
   if(now>exp_next_spd_evt) {
     uint32_t diff = now - exp_next_spd_evt;
-    uint32_t delta_adjusted = u16_speed_delta + diff * 0.9765625;
+    uint32_t delta_adjusted = u16_speed_delta + diff * 1.024f; //milliseconds into 1/1024ths of a second
     if ( delta_adjusted > 0)
-      est_wheel_rpm = 61140.0 * float(u32_WheelCount_delta)/float(delta_adjusted);
+      est_wheel_rpm = 61440.0 * float(u32_WheelCount_delta)/float(delta_adjusted);
   }else{
     est_wheel_rpm = raw_wheel_rpm;
   }

--- a/src/HAL/Bluetooth/csc.hpp
+++ b/src/HAL/Bluetooth/csc.hpp
@@ -57,9 +57,12 @@ class csc : public BT_Device {
     // Body sensor location value is 8 bit
     const char* feat_str[4] = {"other", "Speed", "Cadence", "Speed & Cadence"};
     const float f32_circ = 2127;
-    uint32_t u32_WheelCount_Prev;
-    uint16_t u16_SpeedEvt_Prev, u16_CrankCount_Prev, u16_CrankEvt_Prev;
-    uint8_t u8_feature, u8_location;
+    // csc objects are heap-allocated via `new csc(MAC)`, so these get no
+    // static zero-init. begin() already zeroed the two presence flags; the
+    // rest were left indeterminate.
+    uint32_t u32_WheelCount_Prev = 0;
+    uint16_t u16_SpeedEvt_Prev = 0, u16_CrankCount_Prev = 0, u16_CrankEvt_Prev = 0;
+    uint8_t u8_feature = 0, u8_location = 0;
     uint32_t millis_at_spd_evt = 0, millis_at_cad_evt = 0;
     uint32_t exp_next_spd_evt= 0, exp_next_cad_evt=0;
     uint32_t u32_WheelCount_delta = 0;
@@ -84,8 +87,9 @@ class csc : public BT_Device {
     }
 
   public:
-    bool b_speed_present, b_cadence_present;
-    float raw_wheel_rpm, f32_wheel_rpm, f32_cadence_raw, f32_cadence;
+    bool b_speed_present = false, b_cadence_present = false;
+    float raw_wheel_rpm = 0.0f, f32_wheel_rpm = 0.0f;
+    float f32_cadence_raw = 0.0f, f32_cadence = 0.0f;
     virtual ~csc(){};
     
     static void create_csc(MacAddress MAC)

--- a/src/HAL/Bluetooth/hrm.cpp
+++ b/src/HAL/Bluetooth/hrm.cpp
@@ -15,7 +15,13 @@ void hrm::hrm_notify_callback(BLEClientCharacteristic* chr, uint8_t* data, uint1
 }
 
 void hrm::hrm_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) {
+  // Heart Rate Measurement: uint8 flags, then either a uint8 or a uint16 BPM
+  // depending on flag bit 0. Both forms were previously read without checking
+  // len, so a 1-byte notification read past the end of the buffer.
+  if (len < 2) return;
+
   if ( data[0] & bit(0) ) {
+    if (len < 3) return;
     memcpy(&u16_bpm, data+1, 2);
   } else {
     u16_bpm = data[1];
@@ -96,11 +102,18 @@ void hrm::discover(uint16_t conn_handle) {
     // Body sensor location value is 8 bit
     const char* body_str[] = { "Other", "Chest", "Wrist", "Finger", "Hand", "Ear Lobe", "Foot" };
 
-    // Read 8-bit hrm_loc value from peripheral
+    // Read 8-bit hrm_loc value from peripheral. The value is controlled by the
+    // remote device and the spec reserves everything above 6, so it must be
+    // range checked before indexing -- an out-of-range value previously read
+    // an arbitrary pointer out of flash and printed through it.
     uint8_t loc_value = hrm_loc.read8();
-    
+
     Serial.print("Body Location Sensor: ");
-    Serial.println(body_str[loc_value]);
+    if (loc_value < (sizeof(body_str) / sizeof(body_str[0]))) {
+      Serial.println(body_str[loc_value]);
+    } else {
+      Serial.print("reserved ("); Serial.print(loc_value); Serial.println(")");
+    }
   }else
   {
     Serial.println("Found NONE");

--- a/src/HAL/Bluetooth/hrm.cpp
+++ b/src/HAL/Bluetooth/hrm.cpp
@@ -27,6 +27,8 @@ void hrm::hrm_notify(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len) 
     u16_bpm = data[1];
   }
   
+  _hasData = true;
+
   if (ENABLE_BLUETOOTH_DEBUG) {
     Serial.print("Received HRM Measurement: ");
     Serial.print(u16_bpm);
@@ -150,13 +152,20 @@ void hrm::discover(uint16_t conn_handle) {
 }
 
 data_record hrm::getHRM() {
+  // Only average devices that have actually reported. Previously `live` was
+  // set for any device in the list, including one created at boot from
+  // devices.txt that had never connected.
   data_record heartrates = {0, false};
+  uint16_t contributors = 0;
   for (hrm* dev : _hrmDevices) {
-    heartrates.value += dev->f32_bpm;
-    heartrates.live = true;
+    if (dev->hasData()) {
+      heartrates.value += dev->f32_bpm;
+      heartrates.live = true;
+      contributors++;
+    }
   }
-  if (_hrmDevices.size() > 0) {
-    heartrates.value /= _hrmDevices.size();
+  if (contributors > 0) {
+    heartrates.value /= contributors;
   }
   return heartrates;
 }

--- a/src/HAL/Bluetooth/hrm.hpp
+++ b/src/HAL/Bluetooth/hrm.hpp
@@ -16,6 +16,7 @@ private:
   BLEClientCharacteristic hrm_loc = BLEClientCharacteristic(UUID16_CHR_BODY_SENSOR_LOCATION);
   uint16_t u16_bpm=0;
   float f32_bpm=0;
+  bool _hasData=false;   // set once a measurement notification has been decoded
 
   static std::vector<hrm*> _hrmDevices;
 
@@ -48,6 +49,8 @@ public:
   };
 
   static data_record getHRM();
+
+  bool hasData() const { return _hasData; }
 
     void begin();
 

--- a/src/HAL/BluetoothInterface.hpp
+++ b/src/HAL/BluetoothInterface.hpp
@@ -17,19 +17,20 @@ enum E_Type_BT_Mode {
 };
 
 struct BluetoothDevice {
-    char name[32];
+    char name[32] = {0};
     MacAddress MAC;
-    uint16_t batt;
-    E_Type_BT_Device type;
-    bool connected;
-    bool saved;
+    uint16_t batt = 100;
+    // Defaulted so a device whose advertisement matches none of the three
+    // service UUIDs does not carry an indeterminate type into createDevice().
+    E_Type_BT_Device type = E_Type_BT_Device::bt_csc;
+    bool connected = false;
+    bool saved = false;
 
     BluetoothDevice(){}
-    BluetoothDevice(uint8_t* macAddr, bool conn = false, bool save=false) : 
+    BluetoothDevice(uint8_t* macAddr, bool conn = false, bool save=false) :
         MAC(macAddr),
         connected(conn),
-        saved(save) {
-        batt = 100; }
+        saved(save) {}
 } ;
 
 #endif /* BLUETOOTHINTERFACE_H */


### PR DESCRIPTION
Addresses **C4, C5, H5, H16, M9, M20** from #3, plus three arithmetic bugs found during the work that are not in the issue. Six commits, one per fix.

> Depends on #4 for the build. Also **excludes C1** (the BLE/main-loop data race) — that is a design change, not a patch, and goes in a separate PR so these don't wait on it.

## C4 — unvalidated payloads from remote sensors

`csc_notify`, `cps_notify` and `hrm_notify` all took a `uint16_t len` and never used it, reading fixed offsets driven only by flag bits. `hrm_notify` read `data[1]` unconditionally, so a 1-byte notification was already out of bounds.

Also range-checks the body sensor location before using it as an array index:

```cpp
const char* body_str[] = { "Other", ..., "Foot" };   // 7 entries
uint8_t loc_value = hrm_loc.read8();                 // 0..255, remote-controlled
Serial.println(body_str[loc_value]);
```

The spec reserves everything above 6, so a non-conforming peripheral could index ~248 entries past the array and print through whatever pointer it found.

## C5 — buffer overflow from `devices.txt`

```cpp
.toCharArray(newDevice.name, device["name"].as<String>().length() + 1);
```

Size argument was the **source** length, not the destination capacity. `name` is `char[32]`, `devices.txt` is user-editable on the SD card, and BLE names are often longer than 31 chars — so it wrote through the rest of the struct.

## H5 — CPS measurement parsing was byte-misaligned

Cycling Power Measurement is `uint16 flags, sint16 power, ...`. The code used the **CSC** layout — 8-bit flags, first value at offset 1. CSC really does have 8-bit flags; CPS does not. So:

- power straddled the flags high byte and the power low byte
- every optional field after it shifted by one
- flag bits misassigned — bit 1 is the balance *reference*, not cadence-present; bit 2 is torque; bit 4 is wheel revs
- cadence was read as a transmitted value. It isn't transmitted; it must be derived as a rate from the crank revolution pair on bit 5
- pedal balance read as `sint16/100` rather than `uint8` in ½ % units

Rewritten against the spec with per-field bounds checks. The 1/32 Nm torque scaling was right and is kept.

## H16 — power meter reported uninitialised memory from boot

cppcheck flagged every `cps` value member as uninitialised, and unlike the `HAL`/`App` warnings these are real — `csc`/`cps`/`hrm` are heap-allocated via `new`, so no static zero-init. `csc::begin()` defensively zeroes its flags; **`cps::begin()` initialises nothing**, and `getPower()` had no presence guard:

```cpp
power.value += dev->f32_power;   // indeterminate
power.live   = true;             // unconditionally "live"
```

`create_cps()` runs during `loadDevices()` at `BOOT` and `HAL::update()` calls `getPower()` every loop after — so with a saved power meter in `devices.txt`, the device displayed *and logged to the FIT file* a garbage float flagged valid, from boot until the first notification.

## Three arithmetic bugs not in the issue

Found while writing the CPS crank-revolution maths:

**1. `61140` is not `60*1024`.** The comment says it is; 60×1024 = **61440**. A digit transposition in all four places. Cadence and wheel RPM read **0.49 % low** — and so does speed, which `App::updateTelemetry` derives from wheel RPM.

**2. `csc::update()` applied the tick↔ms conversion backwards.**

```cpp
uint32_t delta_adjusted = u16_crank_delta + diff * 0.9765625;
//convert milliseconds into 1/1024ths of a second
```

`diff` is in ms being added to a value in 1/1024 s ticks, so it needs 1024/1000 = **1.024**. `0.9765625` is 1000/1024 — correct where used on lines 152/198, backwards here. **4.86 % error** in the between-notification estimate, in both cadence and speed.

**3. Counter wraparound off by one** — `u16_SpeedEvt + (65535 - prev)` should be 65536, or rather nothing: these are free-running unsigned counters and plain subtraction wraps correctly. Replaced the branches with a single subtraction.

## M9 / M20

Aggregate getters divided by total device count rather than contributing count — two CSC sensors with only one reporting speed halved the reading. And five unconditional `Serial.print` calls in the CPS notify callback (~10 ms of blocking UART per notification, on the SoftDevice's task) are now behind `ENABLE_BLUETOOTH_DEBUG`, matching what `hrm.cpp` already did.

## Verification

`pio run` clean after every commit, no new warnings. Flash 420148 → 420708 bytes (+560).

**Not flashed to hardware,** and this PR needs it more than #5 did. Worth checking on-device: power/cadence from a real power meter (H5 changes every field), and that cadence/speed now read ~0.5 % higher (the `61440` fix). The bounds checks and initialisers are behaviour-preserving on well-formed input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)