### PR TITLE
Sensors: fix battery scale, wire up temperature, correct IMU units, default wheel size

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -221,7 +221,11 @@ void App::updateTelemetry() {
     float speed = 0;
     float circumference = model.bike().get().wheelCircumference;
 
-    if (wheelRPM.live) {
+    // Treat a zero circumference as "no wheel data" rather than computing a
+    // speed of zero from it. Without this, an unconfigured circumference
+    // silently suppressed the GPS fallback: wheelRPM.live is true whenever a
+    // CSC sensor is connected, so the first branch was taken and produced 0.
+    if (wheelRPM.live && circumference > 0) {
         speed = wheelRPM.value * circumference * 0.00006;
     } else if (gpsSpeed.live) {
         speed = gpsSpeed.value;

--- a/src/DataModel/BikeDataProvider.hpp
+++ b/src/DataModel/BikeDataProvider.hpp
@@ -5,8 +5,12 @@
 #include "TelemetryDataProvider.hpp"
 
 struct BikeData {
-    uint16_t mass;
-    uint16_t wheelCircumference;
+    uint16_t mass = 10;                    // kg
+    // Millimetres. Defaulted to a 700x25c wheel rather than left at zero:
+    // BikeData is value-initialised, and a zero circumference makes
+    // App::updateTelemetry compute a speed of exactly 0 from a live wheel
+    // sensor, with no indication why.
+    uint16_t wheelCircumference = 2105;
 };
 
 class BikeDataProvider {

--- a/src/HAL/AltitudeFusion.cpp
+++ b/src/HAL/AltitudeFusion.cpp
@@ -7,8 +7,15 @@ void AltitudeFusion::altitudeIMUUpdate(float accZ) {
 
     if (dt <= 0.0f || dt > 0.1f) dt = 0.01f; // Basic safety check
 
-    // Subtract gravity AND our learned vibration bias
-    float linear_acc_z = accZ - 9.80665f - acc_bias_z;
+    // accZ arrives in g -- LSM6DS3::readFloatAccelZ() returns multiples of
+    // standard gravity, not m/s^2 -- so it has to be converted before gravity
+    // is subtracted. Previously this computed accZ - 9.80665, which at rest is
+    // 1.0 - 9.81 = -8.81 m/s^2 of fictitious downward acceleration fed straight
+    // into the velocity integrator. The barometer correction absorbed most of
+    // it into acc_bias_z over time, which is why altitude still looked
+    // reasonable, but est_vel_z -- and therefore rise(), and the grade tile
+    // that divides by it -- was not trustworthy.
+    float linear_acc_z = (accZ * STANDARD_GRAVITY) - STANDARD_GRAVITY - acc_bias_z;
 
     // Kinematic integration step
     est_alt += est_vel_z * dt;

--- a/src/HAL/AltitudeFusion.hpp
+++ b/src/HAL/AltitudeFusion.hpp
@@ -4,12 +4,15 @@
 #include <Arduino.h>
 #include <limits.h>
 
+// Standard gravity, m/s^2. The IMU reports acceleration in multiples of this.
+static constexpr float STANDARD_GRAVITY = 9.80665f;
+
 class AltitudeFusion {
     private:
 
-    unsigned long last_micros;
+    unsigned long last_micros = 0;
     uint32_t lastGPSAltUpdate = (uint32_t)ULONG_MAX;
-    bool altitudeValidLast;
+    bool altitudeValidLast = false;
 
     float est_alt = 0.0f;           // Cleaned Absolute Altitude (meters above sea level)
     float est_vel_z = 0.0f;         // Vertical speed / Climb rate (m/s)

--- a/src/HAL/HAL.cpp
+++ b/src/HAL/HAL.cpp
@@ -82,6 +82,18 @@ void HAL::update() {
     } else {
         f32_alt = _LC76G.gps().altitude.meters();
     }
+
+    // Ambient temperature. This was never assigned anywhere, so getTemperature()
+    // returned a constant 0.0 (HAL is a function-local static, so zero-init
+    // rather than garbage -- which is why it looked plausible on screen).
+    // The DPS368 reading is the better source; fall back to the RTC's own
+    // sensor when the barometer has not produced a valid sample.
+    const dps_data& dps = sensorSystem.dps();
+    if (dps.dpsValid) {
+        f32_temp = dps.f32_DSP_Temp;
+    } else {
+        f32_temp = dps.f32_RTC_Temp;
+    }
     
     wheelRPM = csc::getSpeed();
     gpsKmh = {0, false};

--- a/src/HAL/Sensors.cpp
+++ b/src/HAL/Sensors.cpp
@@ -110,7 +110,23 @@ bool SensorSystem::update(bool i2cBusy) {
         float vBat = adcVoltage * (1510.0 / 510.0);
 
         digitalWrite(VBAT_ENABLE, HIGH);
-        _nBattPercentage = (int)constrain(vBat / 0.036f, 0.0f, 100.0f);
+
+        // Map the cell's usable range, not 0 V to 3.6 V.
+        //
+        // The previous formula was `vBat / 0.036f`, a linear ramp from zero
+        // volts reaching 100% at 3.6 V. For the LiPo this board actually uses
+        // that reads 100% all the way from 4.2 V down to 3.6 V -- roughly a
+        // quarter of the remaining charge -- and still reports 83% at 3.0 V,
+        // by which point the cell is empty. The gauge never left the top of
+        // its range, so it carried no information.
+        //
+        // A straight line over 3.30 V - 4.20 V is still an approximation of a
+        // LiPo discharge curve, which is flat in the middle and steep at both
+        // ends, but it is monotonic across the range that matters and reaches
+        // 0% at a sensible cutoff.
+        _nBattPercentage = (int)constrain((vBat - BAT_EMPTY_V) * 100.0f
+                                              / (BAT_FULL_V - BAT_EMPTY_V),
+                                          0.0f, 100.0f);
         lastBATTime = millis();
     }
     return update; 

--- a/src/HAL/Sensors.hpp
+++ b/src/HAL/Sensors.hpp
@@ -11,7 +11,17 @@
 #define LSM6DS3_ADDR 0x6A //I2C device address 0x6A
 #define BAT_HIGH_CHARGE 22  // HIGH for 50mA, LOW for 100mA
 #define BAT_CHARGE_STATE 23 // LOW for charging, HIGH not charging
+
+// Volts per ADC least-significant bit, at the default 10-bit resolution and
+// 3.6 V reference. (The name says MV/LBS; it is neither millivolts nor LBS.
+// Left as-is to avoid churn -- see the cleanup PR.)
 #define VBAT_MV_PER_LBS (0.003395996F)
+
+// Usable terminal-voltage range of the LiPo cell, used to scale the reported
+// battery percentage. 3.30 V is a conservative empty point that leaves margin
+// above the protection cutoff.
+#define BAT_FULL_V  (4.20F)
+#define BAT_EMPTY_V (3.30F)
 
 #define DS3231 true
 


### PR DESCRIPTION
Addresses **H3, H4, H7, M18** from #3. Four commits, one per fix. These are the readings a rider actually looks at, and each was wrong in a way that looked plausible on screen rather than obviously broken.

> Depends on #4 for the build. Touches `src/App.cpp` in two lines (the H7 fallback guard) — the later `fix/app-core` PR also touches that file, but different functions, so they should merge cleanly.

## H4 — temperature was always exactly 0 °C

`HAL::f32_temp` was declared, returned by `getTemperature()`, and **never assigned anywhere**. `grep` finds exactly two references: the declaration and the getter. `HAL` is a function-local static, so the value was a clean zero rather than garbage — which is precisely why a permanent 0 °C looked plausible.

Both real sources were already being sampled and then dropped — `_f32_RTC_Temp` from the DS3231 and `dps_dat.f32_DSP_Temp` from the DPS368. The plumbing through to `HAL` was simply never connected.

## H3 — the battery gauge carried no information

```cpp
_nBattPercentage = (int)constrain(vBat / 0.036f, 0.0f, 100.0f);
```

A linear ramp from **zero volts**, hitting 100% at 3.6 V. Against a real LiPo:

| Cell | Reported (old) | Reported (new) | Actual |
|---|---|---|---|
| 4.20 V | 100% | 100% | 100% |
| 3.70 V | 100% | 44% | ~40% |
| 3.60 V | 100% | 33% | ~25% |
| 3.00 V | **83%** | 0% | 0% |

It read 100% for most of the discharge and never dropped below 83% before the cell was flat. Now scales over 3.30–4.20 V with named endpoints in `Sensors.hpp`. Still a straight line — a lookup table against a measured curve would be the next improvement — but monotonic across the range that matters and reaching zero at a sensible cutoff.

## M18 — accelerometer in g, gravity subtracted in m/s²

```cpp
float linear_acc_z = accZ - 9.80665f - acc_bias_z;
```

`readFloatAccelZ()` returns **g**. Confirmed in the library source rather than assumed — `calcAccel` is `(float)input * 0.061 * (settings.accelRange >> 1) / 1000`, the mg/LSB sensitivity divided by 1000.

So at rest this computed `1.0 - 9.81 = -8.81 m/s²` of fictitious downward acceleration and integrated it. The barometer correction absorbs most of the drift into `acc_bias_z` within a few seconds, which is why altitude still looked about right and this went unnoticed. The casualty is `est_vel_z`: `rise()` feeds the grade calculation in `App::updateTelemetry`, so the grade tile was reading off a velocity estimate built on an 8.8 m/s² offset.

**Scope note:** this corrects units only. The filter still treats the raw device Z axis as vertical with no tilt compensation, so lean and pitch still project horizontal acceleration into the estimate. Larger change, not attempted here.

## H7 — zero wheel circumference silently suppressed the GPS fallback

`BikeData` had no member initialisers and is value-initialised, so `wheelCircumference` was 0 until `/bikeStats.txt` loaded. `wheelRPM.live` is true whenever a CSC sensor is connected, so the first branch was taken, produced exactly zero, and the `else if (gpsSpeed.live)` fallback never ran. A device with no `bikeStats.txt` showed **0 km/h while moving with a working speed sensor**.

Defaults to 2105 mm (700×25c), and the wheel branch now requires a non-zero circumference so a zero from any source falls through to GPS.

## Verification

`pio run` clean after each commit, no new warnings. Flash 420148 → 420356 bytes (+208).

**Not flashed to hardware.** Worth checking on-device: battery percentage should now track the discharge instead of sitting at 100; the temperature tile should show a real value; and with `bikeStats.txt` deleted, speed should come from GPS rather than reading zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)