### PR TITLE
App: fix GPS time sync, clamp layout on load, handle file open failures

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -524,8 +524,14 @@ void App::loadLayout() {
             displays.push_back(disp);
         }
 
-        uint8_t rows = jsonBuffer["rows"];
-        uint8_t cols = jsonBuffer["cols"];
+        // Clamp on load rather than making every consumer defend itself.
+        // ArduinoJson yields 0 for a missing or unparseable key, and
+        // MainScreen::onEnter divides by both of these to compute its grid
+        // pitch -- so a truncated layout.txt was a divide by zero on the
+        // main screen. DisplayEditScreen already clamped to 2..5; this makes
+        // the guarantee hold at the point the data enters the model.
+        uint8_t rows = constrain((int)(jsonBuffer["rows"] | 0), LAYOUT_MIN_ROWS, LAYOUT_MAX_ROWS);
+        uint8_t cols = constrain((int)(jsonBuffer["cols"] | 0), LAYOUT_MIN_COLS, LAYOUT_MAX_COLS);
 
         model.layout().update({displays, rows, cols});
         dataFile.close();

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -234,8 +234,6 @@ void App::updateTelemetry() {
         grade = altVelocity.value*3.6f*100.0f/speed;
     }
 
-    float gearRatio = HAL::inst().getCadence()/wheelRPM.value;
-
     model.telemetry().update({  HAL::inst().getIMUData(),
                                 HAL::inst().getDPSData(),
                                 HAL::inst().getBatteryPercentage(),
@@ -388,6 +386,10 @@ void App::saveBiometrics() {
         _storage->remove("/biometrics.txt");
 
     File32 dataFile = _storage->openFile("/biometrics.txt", FILE_WRITE);
+    if (!dataFile) {
+        Serial.println("[App] failed to open /biometrics.txt for writing");
+        return;
+    }
 
     serializeJson(doc, dataFile);
     dataFile.close();
@@ -395,10 +397,14 @@ void App::saveBiometrics() {
 
 void App::loadBiometrics() {
     
-    if (_storage->exists("biometrics.txt")) {
+    if (_storage->exists("/biometrics.txt")) {
         Serial.println("Found biometrics.txt");
         // Open file for reading
         File32 dataFile = _storage->openFile("/biometrics.txt", FILE_READ);
+        if (!dataFile) {
+            Serial.println("[App] failed to open /biometrics.txt for reading");
+            return;
+        }
         // Allocate the memory pool on the stack.
         JsonDocument jsonBuffer;
         // Parse the root object
@@ -406,7 +412,9 @@ void App::loadBiometrics() {
         DeserializationError error = deserializeJson(jsonBuffer, dataFile);
 
         if (error) {
-            Serial.print("deserializeJson() failed: ");
+            Serial.print("[App] deserializeJson() failed for /biometrics.txt: ");
+            Serial.println(error.c_str());
+            dataFile.close();
             return;
         }
 
@@ -439,6 +447,10 @@ void App::saveBikeStats() {
         _storage->remove("/bikeStats.txt");
 
     File32 dataFile = _storage->openFile("/bikeStats.txt", FILE_WRITE);
+    if (!dataFile) {
+        Serial.println("[App] failed to open /bikeStats.txt for writing");
+        return;
+    }
 
     serializeJson(doc, dataFile);
     dataFile.close();
@@ -446,10 +458,14 @@ void App::saveBikeStats() {
 
 void App::loadBikeStats() {
     
-    if (_storage->exists("bikeStats.txt")) {
+    if (_storage->exists("/bikeStats.txt")) {
         Serial.println("Found bikeStats.txt");
         // Open file for reading
         File32 dataFile = _storage->openFile("/bikeStats.txt", FILE_READ);
+        if (!dataFile) {
+            Serial.println("[App] failed to open /bikeStats.txt for reading");
+            return;
+        }
         // Allocate the memory pool on the stack.
         JsonDocument jsonBuffer;
         // Parse the root object
@@ -457,7 +473,9 @@ void App::loadBikeStats() {
         DeserializationError error = deserializeJson(jsonBuffer, dataFile);
 
         if (error) {
-            Serial.print("deserializeJson() failed: ");
+            Serial.print("[App] deserializeJson() failed for /bikeStats.txt: ");
+            Serial.println(error.c_str());
+            dataFile.close();
             return;
         }
 
@@ -479,7 +497,7 @@ void App::saveLayout() {
     doc["rows"] = l.rows;
     doc["cols"] = l.cols;
 
-    for (int j = 0; j < l.displays.size(); j++) {
+    for (size_t j = 0; j < l.displays.size(); j++) {
         d[j]["x0"] = l.displays[j].x0;
         d[j]["y0"] = l.displays[j].y0;
         d[j]["x1"] = l.displays[j].x1;
@@ -491,16 +509,24 @@ void App::saveLayout() {
         _storage->remove("/layout.txt");
 
     File32 dataFile = _storage->openFile("/layout.txt", FILE_WRITE);
+    if (!dataFile) {
+        Serial.println("[App] failed to open /layout.txt for writing");
+        return;
+    }
 
     serializeJson(doc, dataFile);
     dataFile.close();
 }
 
 void App::loadLayout() {
-    if (_storage->exists("layout.txt")) {
+    if (_storage->exists("/layout.txt")) {
         Serial.println("Found layout.txt");
         // Open file for reading
         File32 dataFile = _storage->openFile("/layout.txt", FILE_READ);
+        if (!dataFile) {
+            Serial.println("[App] failed to open /layout.txt for reading");
+            return;
+        }
         // Allocate the memory pool on the stack.
         JsonDocument jsonBuffer;
         // Parse the root object
@@ -508,7 +534,9 @@ void App::loadLayout() {
         DeserializationError error = deserializeJson(jsonBuffer, dataFile);
 
         if (error) {
-            Serial.print("deserializeJson() failed: ");
+            Serial.print("[App] deserializeJson() failed for /layout.txt: ");
+            Serial.println(error.c_str());
+            dataFile.close();
             return;
         }
 
@@ -548,6 +576,10 @@ void App::saveTime() {
         _storage->remove("/time.txt");
 
     File32 dataFile = _storage->openFile("/time.txt", FILE_WRITE);
+    if (!dataFile) {
+        Serial.println("[App] failed to open /time.txt for writing");
+        return;
+    }
 
     serializeJson(doc, dataFile);
     dataFile.close();
@@ -555,10 +587,14 @@ void App::saveTime() {
 }
 
 void App::loadTime() {
-    if (_storage->exists("time.txt")) {
+    if (_storage->exists("/time.txt")) {
         Serial.println("Found time.txt");
         // Open file for reading
         File32 dataFile = _storage->openFile("/time.txt", FILE_READ);
+        if (!dataFile) {
+            Serial.println("[App] failed to open /time.txt for reading");
+            return;
+        }
         // Allocate the memory pool on the stack.
         JsonDocument jsonBuffer;
         // Parse the root object
@@ -566,7 +602,9 @@ void App::loadTime() {
         DeserializationError error = deserializeJson(jsonBuffer, dataFile);
 
         if (error) {
-            Serial.print("deserializeJson() failed: ");
+            Serial.print("[App] deserializeJson() failed for /time.txt: ");
+            Serial.println(error.c_str());
+            dataFile.close();
             return;
         }
         int UTCOffset = jsonBuffer["UTCOffset"];

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -253,12 +253,33 @@ void App::updateTelemetry() {
 
     //when gps time goes valid, check if the RTC time needs to be re-synced
     int UTCoffset = model.time().get().offset();
-    if (gpsLoc.isValid() && !_gpsNowValid) {
-        //load gpsTime into _gpsNow DateTime object, adding in the saved UTC offset
-        _gpsNow = {rtcNow.year(), rtcNow.month(), rtcNow.day(), (uint8_t)((int)gpsNow.hour()+UTCoffset*60), gpsNow.minute(), gpsNow.second()};
-        TimeSpan ts = _gpsNow - rtcNow;
-        if (ts.totalseconds() > 30 || ts.totalseconds() < -30)
-            HAL::inst().setTime(_gpsNow);
+    if (gpsLoc.isValid() && !_gpsNowValid && gpsNow.isValid()) {
+        // GPS reports UTC, and the RTC stores UTC, so no offset conversion
+        // belongs here at all.
+        //
+        // The previous expression was
+        //     (uint8_t)((int)gpsNow.hour() + UTCoffset*60)
+        // which is wrong twice over. timeData::_offset is in MINUTES (see
+        // TimeDataProvider.hpp, and TimeEditScreen which steps it by 30), so
+        // multiplying by 60 scales it by 3600x; and the result was then
+        // truncated to uint8_t. For UTC+10 that is hour + 36000 -> 172. Any
+        // non-zero offset produced an hour above 23, i.e. an invalid DateTime,
+        // and the +/-30s check below then all but guaranteed it was written to
+        // the RTC. Only UTC+0 ever synced correctly.
+        //
+        // Building the date from the GPS date as well as the GPS time also
+        // fixes a second problem: pairing the GPS hour with the RTC's date
+        // broke across midnight, and across any interval where the RTC date
+        // was already wrong -- which is exactly when a resync is needed.
+        TinyGPSDate gpsDate = HAL::inst().getGPSDate();
+        if (gpsDate.isValid()) {
+            _gpsNow = DateTime(gpsDate.year(), gpsDate.month(), gpsDate.day(),
+                               gpsNow.hour(), gpsNow.minute(), gpsNow.second());
+
+            TimeSpan ts = _gpsNow - rtcNow;
+            if (ts.totalseconds() > 30 || ts.totalseconds() < -30)
+                HAL::inst().setTime(_gpsNow);
+        }
     }
     _gpsNowValid = gpsLoc.isValid();
     

--- a/src/DataModel/LayoutDataProvider.hpp
+++ b/src/DataModel/LayoutDataProvider.hpp
@@ -89,10 +89,17 @@ struct DisplayItem {
     }
 };
 
+// Bounds for the telemetry grid. Enforced when a layout is loaded from disk
+// and when one is edited, so consumers can divide by rows/cols safely.
+static constexpr int LAYOUT_MIN_ROWS = 2;
+static constexpr int LAYOUT_MAX_ROWS = 5;
+static constexpr int LAYOUT_MIN_COLS = 2;
+static constexpr int LAYOUT_MAX_COLS = 5;
+
 struct LayoutData {
     std::vector<DisplayItem> displays;
-    uint8_t rows;
-    uint8_t cols;
+    uint8_t rows = LAYOUT_MIN_ROWS;
+    uint8_t cols = LAYOUT_MIN_COLS;
 };
 
 class LayoutDataProvider {

--- a/src/HAL/HAL.hpp
+++ b/src/HAL/HAL.hpp
@@ -64,6 +64,7 @@ class HAL {
 
     TinyGPSLocation getGPSLocation() const { return _LC76G.gps().location; }
     TinyGPSTime getGPSTime() const { return _LC76G.gps().time; }
+    TinyGPSDate getGPSDate() const { return _LC76G.gps().date; }
     DateTime getRTCtime() const { return sensorSystem.now(); }
     imu_data getIMUData() const { return sensorSystem.imu(); }
     dps_data getDPSData() const { return sensorSystem.dps(); }


### PR DESCRIPTION
Addresses **H1, H11, M5, M6** from #3, plus the two `-Wall -Wextra` warnings in `src/App.cpp`. Three commits.

> Depends on #4 for the build. Touches `src/App.cpp`, which #7 also touches — different functions, should merge cleanly either order.

## H1 — GPS time sync only ever worked at UTC+0

```cpp
_gpsNow = {rtcNow.year(), rtcNow.month(), rtcNow.day(),
           (uint8_t)((int)gpsNow.hour()+UTCoffset*60),
           gpsNow.minute(), gpsNow.second()};
```

`timeData::_offset` is in **minutes** — the declaration says so, `to_local()` adds it to the minute field, and `TimeEditScreen` steps it by 30 and displays `offset()/60.0`. Multiplying by 60 scales it by 3600×, and the result is truncated to `uint8_t`:

| Offset | `hour + offset*60` | `(uint8_t)` | Valid hour? |
|---|---|---|---|
| UTC+0 | 12 | 12 | yes |
| UTC+10 | 36012 | 172 | **no** |
| UTC−8 | −28788 | 140 | **no** |
| UTC+5:30 | 19812 | 100 | **no** |

And it doesn't fail safe: the ±30 s drift check immediately below compares that garbage against the RTC, and since the difference always exceeds 30 s, **it writes it**. Every SD timestamp, FIT record and on-screen clock derives from this.

The offset shouldn't be here at all — GPS reports UTC, the RTC stores UTC, and `timeData` applies the offset when producing a local view. That's the only place it belongs.

Also builds the date from the **GPS** date rather than pairing the GPS time with the RTC's date. That combination broke across midnight, and more to the point was wrong in exactly the situation a resync exists to fix — an RTC whose date has already drifted. Both date and time validity are now checked before use.

## H11 — truncated `layout.txt` divided by zero

`MainScreen::onEnter` does `240/_cols` and `240/_rows` with no guard, and `jsonBuffer["rows"]` yields **0** for a missing or unparseable key. `DisplayEditScreen` already defended itself with `constrain(l.rows, 2, 5)`; `MainScreen` did not.

Clamped at the point data enters the model rather than adding a second local guard, so every consumer can rely on the invariant. Bounds are now named constants and `LayoutData` has default member initialisers.

## M5 — open failures silently discarded settings

```cpp
if (_storage->exists("/layout.txt")) _storage->remove("/layout.txt");
File32 dataFile = _storage->openFile("/layout.txt", FILE_WRITE);
serializeJson(doc, dataFile);
```

`openFile` returns a default-constructed `File32` on failure, so this serialised into a closed file and did nothing. Note the ordering — **the old file is deleted first**, so a failed reopen loses the previous settings too.

The load paths had the same gap, and additionally threw away the `DeserializationError` without printing it, so the log line ended with a colon and no reason.

## M6 + warnings

Existence tested without a leading slash, file opened with one — two spellings of the same path in adjacent lines. Both resolve to the FAT root so it worked, but normalised.

Removed `gearRatio` (`-Wunused-variable`) — besides being unused it divided by `wheelRPM.value`, zero whenever the wheel isn't turning, so it computed inf/NaN on most iterations. Widened a loop counter to `size_t` (`-Wsign-compare`). **`src/App.cpp` now compiles clean.**

## Verification

`pio run` clean after each commit. Flash 420148 → 420460 bytes (+312).

**Not flashed to hardware.** H1 is the one to check on-device: set a non-zero UTC offset, get a fix, and confirm the RTC ends up at the correct UTC time rather than being written with a garbage hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)