### PR TITLE
Loggers: rides were recorded 3.6x too fast; handle FIT open failure

### DIFF
--- a/src/Loggers/FITLogger.cpp
+++ b/src/Loggers/FITLogger.cpp
@@ -126,7 +126,8 @@ void FITLogger::addTrackpoint(const Trackpoint& tp) {
     _writer.writeS32(toSemicircles(tp.longitude));
     _writer.writeU16(altitudeEncoded);
     _writer.writeU32(static_cast<uint32_t>(tp.distance * 100.0));      // cumulative, scale 100
-    _writer.writeU16(static_cast<uint16_t>(tp.speed * 1000.0));        // scale 1000
+    // FIT speed is m/s at scale 1000; Trackpoint::speed is km/h.
+    _writer.writeU16(static_cast<uint16_t>(kmhToMs(tp.speed) * 1000.0));
     _writer.writeU8(tp.heartRate > 0 ? static_cast<uint8_t>(tp.heartRate) : 0xFF);
     _writer.writeU8(tp.cadence > 0 ? static_cast<uint8_t>(tp.cadence) : 0xFF);
     _writer.writeU16(tp.power > 0 ? static_cast<uint16_t>(tp.power) : 0xFFFF);
@@ -135,7 +136,7 @@ void FITLogger::addTrackpoint(const Trackpoint& tp) {
 
     Lap& lap = laps.back();
     lap.parts++;
-    if (tp.speed > lap.maxSpeed) lap.maxSpeed = static_cast<float>(tp.speed);
+    if (tp.speed > lap.maxSpeed) lap.maxSpeed = static_cast<float>(tp.speed);   // km/h, converted on write
     if (tp.heartRate > 0) {
         lap.totalHRM += static_cast<float>(tp.heartRate);
         if (tp.heartRate > lap.maxHRM) lap.maxHRM = static_cast<float>(tp.heartRate);
@@ -181,7 +182,7 @@ void FITLogger::writeLapMessage(const Lap& lap, uint32_t startTimeFit, uint32_t 
     _writer.writeU32(startTimeFit);
     _writer.writeU32(elapsedSeconds * 1000); // scale 1000
     _writer.writeU32(static_cast<uint32_t>(lap.totalDistance * 100)); // scale 100
-    _writer.writeU16(static_cast<uint16_t>(lap.maxSpeed * 1000));
+    _writer.writeU16(static_cast<uint16_t>(kmhToMs(lap.maxSpeed) * 1000));   // m/s, scale 1000
     _writer.writeU8(avgHr);
     _writer.writeU8(maxHr);
     _writer.writeU8(avgCadence);

--- a/src/Loggers/FITLogger.cpp
+++ b/src/Loggers/FITLogger.cpp
@@ -97,7 +97,14 @@ void FITLogger::startLogging(const timeData& currentTime) {
 
     // TODO: match your existing filename scheme (date/time-based, etc.)
     String path = "/activity_" + String(static_cast<unsigned long>(currentTime.unixtime())) + ".fit";
-    _writer.open(path);
+    _open = _writer.open(path);
+    if (!_open) {
+        // Every write below is a no-op on a closed File32, so without this the
+        // whole ride was silently discarded and finaliseLogging() would then
+        // seek and patch a header that was never written.
+        Serial.print("[FITLogger] failed to open "); Serial.println(path);
+        return;
+    }
 
     writeDefinitionsOnce();
 
@@ -212,6 +219,8 @@ void FITLogger::writeActivityMessage(uint32_t endTimeFit) {
 }
 
 bool FITLogger::finaliseLogging() {
+    if (!_open) return false;   // nothing was ever written
+
     uint32_t endFit = toFitTimestamp(_currentTime.unixtime());
 
     if (!laps.empty()) {
@@ -223,5 +232,6 @@ bool FITLogger::finaliseLogging() {
     writeActivityMessage(endFit);
 
     _writer.close();
+    _open = false;
     return true;
 }

--- a/src/Loggers/FITLogger.hpp
+++ b/src/Loggers/FITLogger.hpp
@@ -34,7 +34,13 @@ public:
     bool finaliseLogging() override;
  
     const timeDuration elapsed_Total() const override { return _currentTime - _startTime; }
-    const timeDuration elapsed_Lap() const override { return _currentTime - laps.back().startTime; }
+    // laps.back() on an empty vector is undefined behaviour. It is empty
+    // whenever startLogging bailed out (e.g. the file would not open), and
+    // App::update calls this every iteration while in AppState::LOGGING.
+    const timeDuration elapsed_Lap() const override {
+        if (laps.empty()) return timeDuration(0);
+        return _currentTime - laps.back().startTime;
+    }
  
     std::vector<Lap> laps; // kept public to match original's `laps.back()` usage
  
@@ -48,6 +54,7 @@ private:
                                     // used to derive this lap's totalDistance on rollover
  
     bool _definitionsWritten = false;
+    bool _open = false;   // did the .fit file actually open?
     void writeDefinitionsOnce();
  
     // local message type IDs (0-15 max per FIT spec; we use a handful)

--- a/src/Loggers/FITWriter.cpp
+++ b/src/Loggers/FITWriter.cpp
@@ -89,7 +89,13 @@ void FitWriter::writeS32(int32_t v)  { rawWrite(reinterpret_cast<uint8_t*>(&v), 
 
 void FitWriter::writeString(const char* s, uint8_t fieldSize) {
     uint8_t buf[64] = {0}; // FIT strings are short; 64 is generous headroom
-    uint8_t len = fieldSize > 64 ? 64 : fieldSize;
+    uint8_t len = fieldSize > sizeof(buf) ? sizeof(buf) : fieldSize;
+    if (len == 0) return;
+
+    // len - 1 with len == 0 promoted to int -1 and converted to size_t, so
+    // strncpy was handed SIZE_MAX. Guarded above; the field is also always
+    // NUL-terminated because buf is zero-initialised and at most len-1 bytes
+    // are copied into it.
     strncpy(reinterpret_cast<char*>(buf), s, len - 1);
     rawWrite(buf, len);
 }

--- a/src/Loggers/ILogger.hpp
+++ b/src/Loggers/ILogger.hpp
@@ -11,9 +11,16 @@ struct Trackpoint {
     double heartRate;    // Optional
     double power;        // Optional
     double cadence;      // Optional
-    double speed;        // Optional: Instantaneous speed in meters per second
+    // Instantaneous speed in KILOMETRES PER HOUR, matching Telemetry::speed,
+    // which is what App::update passes in. This previously said metres per
+    // second while receiving km/h, and FITLogger encoded it as m/s -- so every
+    // logged ride was 3.6x too fast. Loggers must convert on the way out.
+    double speed;
     double distance;     // Cumulative distance in meters
 };
+
+// FIT and TCX both want speed in m/s; the telemetry pipeline works in km/h.
+inline double kmhToMs(double kmh) { return kmh / 3.6; }
 
 struct Lap {
   timeData startTime;

--- a/src/Loggers/TCXLogger.cpp
+++ b/src/Loggers/TCXLogger.cpp
@@ -65,7 +65,7 @@ void TCXLogger::writeLapHeader(uint16_t lapIndex, File32 *file) {
     // Initialize total time, distance, etc. 
     file->print("        <TotalTimeSeconds>");file->print(ts._totalSeconds);file->print("</TotalTimeSeconds>\n");
     file->print("        <DistanceMeters>");file->print(lp.totalDistance);file->print("</DistanceMeters>\n");
-    file->print("        <MaximumSpeed>");file->print(lp.maxSpeed,2);file->print("</MaximumSpeed>\n");
+    file->print("        <MaximumSpeed>");file->print(kmhToMs(lp.maxSpeed),2)   /* m/s */;file->print("</MaximumSpeed>\n");
     file->print("        <Calories>");file->print(Calories);file->print("</Calories>\n");
     file->print("        <AverageHeartRateBpm>\n");
     file->print("          <Value>");file->print(avgHRM,2);file->print("</Value>\n"); // Set to at least 1
@@ -110,7 +110,8 @@ void TCXLogger::addTrackpoint(const Trackpoint& tp) {
         file.print("                <Cadence>");file.print(tp.cadence);file.println("</Cadence>");
     }
     if (tp.speed > 0) { // Optional speed
-        file.print("                <Speed>");file.print(tp.speed);file.println("</Speed>");
+        // TPX Speed is metres per second; Trackpoint::speed is km/h.
+        file.print("                <Speed>");file.print(kmhToMs(tp.speed));file.println("</Speed>");
     }
 
     file.println("              </TPX>");

--- a/src/Loggers/TCXLogger.hpp
+++ b/src/Loggers/TCXLogger.hpp
@@ -44,7 +44,12 @@ class TCXLogger : public ILogger {
     bool finaliseLogging();
 
     const timeDuration elapsed_Total() const {return _currentTime-_startTime;};
-    const timeDuration elapsed_Lap() const {return _currentTime-laps.back().startTime;};
+    // Guarded for the same reason as FITLogger: laps.back() on an empty
+    // vector is undefined behaviour.
+    const timeDuration elapsed_Lap() const {
+        if (laps.empty()) return timeDuration(0);
+        return _currentTime-laps.back().startTime;
+    };
 
 };
 


### PR DESCRIPTION
Addresses **H2, M15** from #3 and the logger half of **M5**. Two commits.

> Depends on #4 for the build.

## H2 — every logged ride is 3.6× too fast

`Trackpoint::speed` was documented as metres per second:

```cpp
double speed;   // Optional: Instantaneous speed in meters per second
```

But `App::update` passes `Telemetry::speed`, which is **km/h** — the field says so, and `App::updateTelemetry` derives it as `wheelRPM.value * circumference * 0.00006` (mm·rpm → km/h). `FITLogger` then encoded that straight into the FIT `speed` field, which is m/s at scale 1000:

```cpp
_writer.writeU16(static_cast<uint16_t>(tp.speed * 1000.0));
```

A 30 km/h ride was recorded as **108 km/h**. Same error in the lap message's `max_speed`, and in the TCX logger's TPX `<Speed>` and `<MaximumSpeed>`.

Distance is unaffected — metres throughout — which is the easiest way to confirm this from an existing `.fit` without a debugger: **distance and average speed disagree by exactly 3.6×**.

Rather than change what the pipeline produces, this makes the interface honest. `Trackpoint::speed` is now documented as km/h — matching what is actually passed — and each logger converts on the way out through a shared `kmhToMs` helper. That keeps the conversion next to the format that requires it, so a third logger can't silently inherit the bug.

## M5 (logger half) — a failed open discarded the whole ride

```cpp
_writer.open(path);        // result ignored
writeDefinitionsOnce();
```

Every subsequent write is a silent no-op on a closed `File32`, so a failed open threw away the entire activity with no indication. `finaliseLogging()` would then `seekSet` and patch a header that was never written.

**That fix exposed a second bug.** `startLogging` clears `laps` before it can fail, and:

```cpp
const timeDuration elapsed_Lap() const { return _currentTime - laps.back().startTime; }
```

`back()` on an empty vector is UB, and `App::update` calls `elapsed_Lap()` on *every iteration* while in `AppState::LOGGING`. Guarded in both loggers. This was noted in the issue's Low section as latent; adding the early return would have made it reachable, so it is fixed here rather than left.

## M15 — `writeString` with a zero field size

```cpp
uint8_t len = fieldSize > 64 ? 64 : fieldSize;
strncpy(dst, src, len - 1);     // len==0 -> int -1 -> SIZE_MAX
```

No callers today, so latent — but it's the kind of helper that gets used later without a second look.

## Verification

`pio run` clean after each commit. Flash 420148 → 420196 bytes (+48).

**Not flashed to hardware.** H2 is straightforward to confirm without a board: record a ride, upload the `.fit`, and check that distance and average speed are now consistent. If you have an existing `.fit` file, the 3.6× discrepancy should be visible in it already.

## Note on TCXLogger

`TCXLogger` is currently dead — `App::begin` has its construction commented out — but it is still compiled and shares `ILogger`, so the H2 fix is applied there too rather than leaving a second logger with a known unit bug. The other TCX defects in #3 (M14: the `356.25` days-per-year, the `uint32_t Calories < 0` clamp, the day-month-year `<Id>`) are **not** touched here — they want a decision on whether that logger stays at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)