### PR TITLE
UI: null-deref on unknown screen, transposed grid validation, unreachable scroll

### DIFF
--- a/src/ui/Screens/BluetoothScreen.hpp
+++ b/src/ui/Screens/BluetoothScreen.hpp
@@ -33,13 +33,13 @@ public:
 
     void onEnter() override {
         refreshDevices();
-        emitAppEvent({AppEventType::DiscoverBluetooth});
+        emitAppEvent({AppEventType::DiscoverBluetooth, 0});
         _selectedIndex = 0;
         _scrollOffset = 0;
     }
 
     void onExit() override {
-        emitAppEvent({AppEventType::ScanBluetooth});
+        emitAppEvent({AppEventType::ScanBluetooth, 0});
     }
 
     void update(float dt) override {

--- a/src/ui/Screens/BluetoothScreen.hpp
+++ b/src/ui/Screens/BluetoothScreen.hpp
@@ -112,9 +112,19 @@ private:
         //scroll index must b 0 to _devices.size() to allow one more for the back button
         _selectedIndex = (_selectedIndex + delta + length) % length;
 
-        if (_selectedIndex<_scrollOffset+visibleDevices && _scrollOffset<0) {
-            _scrollOffset += delta;
-            _scrollOffset = min(_scrollOffset,_devices.size()-visibleDevices);
+        // Scroll so the selection stays visible.
+        //
+        // The previous condition was
+        //     if (_selectedIndex < _scrollOffset+visibleDevices && _scrollOffset<0)
+        // and _scrollOffset is uint32_t, so `_scrollOffset < 0` is always
+        // false and the whole body was unreachable -- devices past the fourth
+        // could never be shown. -Wtype-limits flags it. The old body would
+        // also have underflowed _devices.size()-visibleDevices whenever there
+        // were fewer devices than visible slots.
+        if (_selectedIndex < _scrollOffset) {
+            _scrollOffset = _selectedIndex;
+        } else if (_selectedIndex >= _scrollOffset + visibleDevices) {
+            _scrollOffset = _selectedIndex - visibleDevices + 1;
         }
     }
 };

--- a/src/ui/Screens/DisplayEditScreen.cpp
+++ b/src/ui/Screens/DisplayEditScreen.cpp
@@ -192,6 +192,7 @@ void DisplayEditScreen::moveFocusUp() {
         case FocusField::Rows: focusField = FocusField::Back; break;
         case FocusField::Grid: focusField = FocusField::Cols; break;
         case FocusField::Back: focusField = FocusField::Grid; break;
+        case FocusField::Save: focusField = FocusField::Grid; break;
     }
     gridWidth.invalidate();
     gridHeight.invalidate();
@@ -203,6 +204,7 @@ void DisplayEditScreen::moveFocusDown() {
         case FocusField::Rows: focusField = FocusField::Grid; break;
         case FocusField::Grid: focusField = FocusField::Back; break;
         case FocusField::Back: focusField = FocusField::Cols; break;
+        case FocusField::Save: focusField = FocusField::Cols; break;
     }
     gridWidth.invalidate();
     gridHeight.invalidate();
@@ -214,6 +216,7 @@ void DisplayEditScreen::moveFocusLeft() {
         case FocusField::Rows: focusField = FocusField::Cols; break;
         case FocusField::Back: focusField = FocusField::Save; break;
         case FocusField::Save: focusField = FocusField::Back; break;
+        case FocusField::Grid: break;   // handled by cursor movement in FOCUS mode
     }
     gridWidth.invalidate();
     gridHeight.invalidate();
@@ -225,6 +228,7 @@ void DisplayEditScreen::moveFocusRight() {
         case FocusField::Rows: focusField = FocusField::Cols; break;
         case FocusField::Back: focusField = FocusField::Save; break;
         case FocusField::Save: focusField = FocusField::Back; break;
+        case FocusField::Grid: break;   // handled by cursor movement in FOCUS mode
     }
     gridWidth.invalidate();
     gridHeight.invalidate();
@@ -311,7 +315,13 @@ bool DisplayEditScreen::validateLayout()
 {
     for (size_t i = 0; i < _displays.size(); ++i)
     {
-        if (!_displays[i].insideGrid(_rows, _cols))
+        // insideGrid(cols, rows) -- the argument order is (cols, rows), and
+        // this call had them reversed while onEnter() had them right. On a
+        // non-square grid that validated against transposed bounds, so it
+        // both accepted out-of-grid layouts and rejected valid ones. An
+        // accepted bad layout is then persisted to layout.txt and reloaded
+        // at boot.
+        if (!_displays[i].insideGrid(_cols, _rows))
             return false;
 
         for (size_t j = i + 1; j < _displays.size(); ++j)

--- a/src/ui/Screens/GPSScreen.hpp
+++ b/src/ui/Screens/GPSScreen.hpp
@@ -40,13 +40,13 @@ class GPSScreen : public UIScreen {
 
             //attach App events
             restGPS.setOnPress([this] () {
-                emitAppEvent({AppEventType::ResetGPS});
+                emitAppEvent({AppEventType::ResetGPS, 0});
             });
             restoreGPSDefaults.setOnPress([this] () {
-                emitAppEvent({AppEventType::RestoreDefaultsGPS});
+                emitAppEvent({AppEventType::RestoreDefaultsGPS, 0});
             });
             saveNVRAM.setOnPress([this] () {
-                emitAppEvent({AppEventType::saveGPSNVRAM});
+                emitAppEvent({AppEventType::saveGPSNVRAM, 0});
             });
 
             //register press event callback to send a change screen event

--- a/src/ui/UIManager.hpp
+++ b/src/ui/UIManager.hpp
@@ -35,10 +35,22 @@ public:
     }
 
     void showScreen(ScreenID id) {
+        // find(), not operator[]: operator[] default-constructs a null
+        // unique_ptr for a missing key, which was then dereferenced. ScreenID
+        // has more enumerators than there are registered screens -- ScreenID::
+        // None in particular is the default argument of emitUIEvent -- so any
+        // ChangeScreen event without an explicit target hard-faulted here.
+        auto it = screens.find(id);
+        if (it == screens.end() || !it->second) {
+            Serial.print("[UIManager] no screen registered for id ");
+            Serial.println(static_cast<int>(id));
+            return;   // leave the current screen active
+        }
+
         if (activeScreen)
             activeScreen->onExit();
 
-        activeScreen = screens[id].get();
+        activeScreen = it->second.get();
         Disp::clear();
         Disp::markDirty(0,0,240,320);
         activeScreen->onEnter();

--- a/src/ui/Widgets/DisplayEditWidget.hpp
+++ b/src/ui/Widgets/DisplayEditWidget.hpp
@@ -87,13 +87,20 @@ public:
                 drawUpArrow();
                 drawDownArrow();
                 break;
-            
+
             case WidgetSubMode::MOVE:
             case WidgetSubMode::RESIZE:
                 drawUpArrow();
                 drawDownArrow();
                 drawLeftArrow();
                 drawRightArrow();
+                break;
+
+            // Neither takes a direction, so neither draws arrows. Listed
+            // explicitly rather than left to fall through the switch, so
+            // -Wswitch stays useful if a mode is added later.
+            case WidgetSubMode::DELETE:
+            case WidgetSubMode::DONE:
                 break;
         }
     }

--- a/src/ui/Widgets/ListView.hpp
+++ b/src/ui/Widgets/ListView.hpp
@@ -20,7 +20,7 @@ public:
 
     void removeItem(size_t index) {
         if (index < _widgets.size()) {
-            totalHeight += (_widgets[index]->height() + margin);
+            totalHeight -= (_widgets[index]->height() + margin);   // was +=
             _widgets.erase(_widgets.begin() + index);
             if (_selectedIndex >= _widgets.size())
                 _selectedIndex = _widgets.empty() ? 0 : _widgets.size() - 1;
@@ -72,6 +72,10 @@ public:
             _widgets[i]->render(_x, y);
             y += _widgets[i]->height() + margin;
         }
+
+        // Nothing to scroll, and dividing by an empty container below would be
+        // an integer division by zero plus a NaN from the float ratio.
+        if (_widgets.empty()) return;
 
         float ratio = _visibleCount /  float(_widgets.size());
         barHeight = int(totalHeight / _widgets.size()) * ratio;


### PR DESCRIPTION
Addresses **C3, H10, M10, M23** from #3 plus the `ListView` guards from the Low section. Four commits.

> Depends on #4 for the build.

## C3 — null dereference on an unregistered screen

```cpp
activeScreen = screens[id].get();   // operator[] inserts a null unique_ptr
Disp::clear();
activeScreen->onEnter();            // null deref
```

`unordered_map::operator[]` default-constructs a missing entry rather than failing. This is reachable without doing anything unusual: `ScreenID` has more enumerators than there are registered screens, and `ScreenID::None` is the **default argument** of `emitUIEvent`:

```cpp
void emitUIEvent(UIEventType type, ScreenID target = ScreenID::None)
```

so any `emitUIEvent(UIEventType::ChangeScreen)` written without an explicit target lands here. It also silently grew the map on every miss.

`begin()` already used `find()` correctly — `showScreen` just never got the same treatment.

## H10 — `insideGrid` arguments transposed between call sites

```cpp
bool insideGrid(uint8_t cols, uint8_t rows) const;   // signature

onEnter():        disp.insideGrid(_cols, _rows)      // correct
validateLayout(): _displays[i].insideGrid(_rows, _cols)
```

On a square grid both agree, which is why it survived. On any non-square grid the save-time validation checked transposed bounds — so it would both accept out-of-grid layouts and reject valid ones. An accepted bad layout then gets written to `layout.txt` and reloaded at boot.

## M10 — the Bluetooth device list could not scroll

```cpp
if (_selectedIndex<_scrollOffset+visibleDevices && _scrollOffset<0) {
```

`_scrollOffset` is `uint32_t`, so `_scrollOffset < 0` is always false and the entire body was unreachable — devices past the fourth could not be reached. `-Wtype-limits` flags it directly. Had it run, it would also have underflowed `_devices.size()-visibleDevices` when there were fewer devices than slots.

Replaced with the standard keep-selection-visible clamp, matching `ListView::clampScroll`.

## M23 + ListView

`moveFocusUp`/`Down` omitted `FocusField::Save`, so Up/Down did nothing while Save was focused (escapable via Left/Right, so a rough edge rather than a trap). `moveFocusLeft`/`Right` omitted `Grid`.

`ListView` had two problems found while reading it for M10:
- `removeItem` **added** the removed item's height to `totalHeight` instead of subtracting — masked because `update()` recomputes it every frame
- `render()` divided by `_widgets.size()` twice with no empty guard: integer division by zero for `barHeight`, NaN from the float ratio. Reachable from `BluetoothScreen` before any device is discovered.

## Verification

`pio run` clean after each commit. **`src/ui` now compiles without warnings** — the four remaining project warnings are all in files owned by other PRs (`App.cpp` → #8, `TCXLogger.cpp` → cleanup, `BigDataWidget.hpp` → cleanup).

Flash 420148 → 420316 bytes (+168).

**Not flashed to hardware.** C3 and M10 are worth confirming on-device: pair five or more sensors and check the list scrolls; and the fix for C3 should turn what was a hard fault into a serial log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)