### PR TITLE
DataModel: hidden accumulator in operator=, O(year) epoch loop, track sampled at loop rate

### DIFF
--- a/src/DataModel/TelemetryDataProvider.hpp
+++ b/src/DataModel/TelemetryDataProvider.hpp
@@ -81,29 +81,14 @@ struct Telemetry {
         , grade(grade_)
     {}
 
-    Telemetry& operator=(const Telemetry& _new) {
-        if (this == &_new) {
-            return *this;
-        }
-
-        imu            = _new.imu;
-        dps            = _new.dps;
-        BattPercentage = _new.BattPercentage;
-        speed          = _new.speed;
-        cadence        = _new.cadence;
-        temperature    = _new.temperature;
-        altitude       = _new.altitude;
-        heartrate      = _new.heartrate;
-        power          = _new.power;
-        validLocation  = _new.validLocation;
-        longitude      = _new.longitude;
-        latitude       = _new.latitude;
-        distance       = _new.distance;
-        totalDistance  += _new.totalDistance;
-        grade          = _new.grade;
-
-        return *this;
-    }
+    // Copy assignment is a plain copy. It previously did
+    //     totalDistance += _new.totalDistance;
+    // which hid a distance accumulator inside operator=, so assigning one
+    // Telemetry to another was not idempotent: `a = b; a = b;` produced a
+    // different result from `a = b`. It happened to give the right answer
+    // because exactly one call site ever assigned a Telemetry. Accumulation
+    // now lives in TelemetryDataProvider::update, where it is visible.
+    Telemetry& operator=(const Telemetry&) = default;
 };
 
 inline TelemetryType& operator++(TelemetryType& t) {
@@ -192,8 +177,16 @@ public:
     uint32_t version() const { return _version; }
 
     void update(const Telemetry& newData) {
+        // Carry the running total across, then add this tick's increment.
+        // Telemetry's constructor seeds totalDistance from the per-tick
+        // distance, so newData.totalDistance is the increment, not a total.
+        // This accumulation used to be hidden inside Telemetry::operator=.
+        const float carried = _data.totalDistance;
+
         _data = newData;
+        _data.totalDistance = carried + newData.totalDistance;
         ++_version;
+
         // append gps point if valid
         if (_data.validLocation) {
             appendPoint(_data.latitude, _data.longitude, millis());

--- a/src/DataModel/TelemetryDataProvider.hpp
+++ b/src/DataModel/TelemetryDataProvider.hpp
@@ -201,19 +201,35 @@ public:
 
 private:
     void appendPoint(double lat, double lon, uint32_t ts) {
-        if (_recent.empty() || _recent.back().lat != lat || _recent.back().lon != lon) {
-            _recent.emplace_back(lat, lon, ts);
-            if (_recent.size() > _maxPoints) {
-                // simple pop-front
-                _recent.erase(_recent.begin());
-            }
+        // Decimate by time. This used to append on every update() where the
+        // position differed at all -- i.e. at main-loop rate -- so the 600
+        // point buffer covered a few seconds of riding rather than the
+        // breadcrumb trail it is meant to be. GPS fixes arrive at 1 Hz, so
+        // anything faster is duplicating the same fix.
+        if (!_recent.empty() && (ts - _lastPointMs) < _minPointIntervalMs) return;
+
+        if (!_recent.empty() && _recent.back().lat == lat && _recent.back().lon == lon) return;
+
+        _recent.emplace_back(lat, lon, ts);
+        _lastPointMs = ts;
+
+        // erase(begin()) is O(n), but with the decimation above it runs at
+        // most once per second over 600 elements. A ring buffer would avoid
+        // the memmove, but consumers rely on _recent being in chronological
+        // order -- MapWidget draws the polyline by iterating it and takes
+        // back() as the current position -- so it is not worth the ordering
+        // hazard for a 14 KB move at 1 Hz.
+        if (_recent.size() > _maxPoints) {
+            _recent.erase(_recent.begin());
         }
     }
-    
+
     Telemetry _data{};
     uint32_t _version = 0;
     std::vector<GPSPoint> _recent;
-    const size_t _maxPoints = 600;
+    uint32_t _lastPointMs = 0;
+    static const size_t _maxPoints = 600;
+    static const uint32_t _minPointIntervalMs = 1000;   // GPS fixes arrive at 1 Hz
 };
 
 #endif

--- a/src/DataModel/TimeDataProvider.hpp
+++ b/src/DataModel/TimeDataProvider.hpp
@@ -94,15 +94,29 @@ private:
         _year = y; _month = mo; _day = d; _hour = h; _minute = min; _second = s;
     }
  
-    // Days elapsed from a fixed epoch (year 0, day 1 of month 1) to the given
-    // date. Used to compute a single linear "total seconds since epoch" value
-    // for operator- / operator+, so calendar differences reduce to plain
-    // integer math without duplicating leap-year handling.
+    // Days elapsed from a fixed epoch to the given date, used to reduce
+    // calendar differences to plain integer arithmetic in operator+/-.
+    //
+    // This was previously two loops -- one over the months of the year, one
+    // over every year from 0 -- which for 2026 is ~2,032 iterations per call,
+    // each doing a leap-year test (three modulo operations). operator-(timeData)
+    // calls it twice, and App::update evaluates both elapsed_Total() and
+    // elapsed_Lap() on every iteration while logging, so this ran roughly
+    // 8,100 times per main loop on a 64 MHz M4 purely to subtract two
+    // timestamps.
+    //
+    // Replaced with Howard Hinnant's days_from_civil, which is O(1). It shifts
+    // the year so that March is month 1, putting the leap day at the end of
+    // the cycle, then counts whole 400-year eras. The result is days relative
+    // to 1970-01-01; the absolute origin does not matter here because every
+    // use is a difference, and unixtime() subtracts EPOCH_DAYS anyway.
     static long days_since_epoch_s(int y, int mo, int d) {
-        long days = d - 1;
-        for (int m = 1; m < mo; ++m) days += get_days_in_month_s(m, y);
-        for (int yr = 0; yr < y; ++yr) days += is_leap_year_s(yr) ? 366 : 365;
-        return days;
+        y -= mo <= 2;
+        const long era = (y >= 0 ? y : y - 399) / 400;
+        const unsigned yoe = static_cast<unsigned>(y - era * 400);            // [0, 399]
+        const unsigned doy = (153 * (mo + (mo > 2 ? -3 : 9)) + 2) / 5 + d - 1; // [0, 365]
+        const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;           // [0, 146096]
+        return era * 146097L + static_cast<long>(doe) - 719468L;
     }
  
     long utc_total_seconds() const {


### PR DESCRIPTION
Addresses **H6, M7, M21, M22** from #3. Three commits.

> Depends on #4 for the build.

## H6 — copy assignment was doing arithmetic

```cpp
distance       = _new.distance;
totalDistance  += _new.totalDistance;      // <-- += inside operator=
grade          = _new.grade;
```

Assigning one `Telemetry` to another was not idempotent: `a = b; a = b;` gives a different result from `a = b`. It produced the right answer only because exactly one call site ever assigns a `Telemetry`, exactly once per tick.

This is a landmine rather than a live bug — the next person to copy a `Telemetry` for logging, snapshot it for a widget, or add a second update path gets silent double-counting, with nothing at the call site suggesting that assignment performs arithmetic.

`operator=` is now `= default`, and the accumulation moves into `TelemetryDataProvider::update` where it's visible. Behaviour is unchanged for the existing caller.

## M7 — ~8,100 loop iterations per main loop to subtract two timestamps

```cpp
for (int m = 1; m < mo; ++m) days += get_days_in_month_s(m, y);
for (int yr = 0; yr < y; ++yr) days += is_leap_year_s(yr) ? 366 : 365;
```

~2,032 iterations per call for 2026, each with a three-modulo leap-year test. `operator-` calls it twice, and `App::update` evaluates **both** `elapsed_Total()` and `elapsed_Lap()` every iteration while logging — so ~8,100 iterations per main loop on a 64 MHz M4.

Replaced with Howard Hinnant's `days_from_civil` (O(1)). The new function returns days relative to 1970-01-01 rather than year 0, which is fine everywhere: `utc_total_seconds()` feeds only differences, and `unixtime()` subtracts `EPOCH_DAYS`, which now evaluates to zero.

**Verified before committing**, since this is the kind of change that's easy to get subtly wrong:
- 3,000 random date pairs in 1990–2100 — differences identical to the old implementation
- 3,000 random dates in 1970–2100 — `unixtime` day counts match Python's `datetime` exactly

The old implementation also matched `datetime`, so this is a like-for-like replacement, not a behaviour change.

## M21 / M22 — the "recent track" covered a few seconds

`appendPoint` ran on every main-loop iteration and appended whenever the position differed *at all*. GPS fixes arrive at 1 Hz, so this stored the same fix repeatedly, or floating-point jitter. The 600-point buffer filled in seconds.

Now decimated to 1 Hz — 600 points is ten minutes of trail.

**On M22 (the O(n) `erase(begin())`):** I did not switch to a ring buffer, and deliberately so. Decimation drops that erase to once per second over 600 elements — a 14 KB memmove at 1 Hz. A ring would avoid it, but consumers depend on `_recent` being chronologically ordered: `MapWidget` draws its polyline by iterating the vector and takes `back()` as the current position. Swapping to a ring silently corrupts the track drawing. I wrote the ring first, spotted the ordering dependency, and reverted — the reasoning is in a comment so the next reader doesn't repeat it.

## Verification

`pio run` clean after each commit, no new warnings. Flash 420148 → 419924 bytes (**−224**, the epoch loop unrolled away).

**Not flashed to hardware.** M7 is behaviour-neutral by construction and cross-checked numerically. Worth confirming on-device that the map trail now spans minutes rather than seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)