### PR TITLE
Map: heap overwrite in the blit, and track projected differently from the tiles

### DIFF
--- a/src/ui/Widgets/MapWidget.cpp
+++ b/src/ui/Widgets/MapWidget.cpp
@@ -221,15 +221,26 @@ void MapWidget::loadTilesToCache() {
 
 void MapWidget::renderFromCache() {
     uint16_t* canvasBuf = canvas.getBuffer();
+    if (!canvasBuf) return;   // GFXcanvas16's malloc can fail and is unchecked
 
-    for (int row = 0; row < MAP_H; ++row) {
-        // Source row in _tilePixels.
-        const uint16_t* src = tilePixels + row * MAP_W;
+    // Clip to the canvas. This writes straight into the framebuffer rather
+    // than going through Adafruit_GFX, so it bypasses the bounds checking in
+    // drawPixel -- nothing here was clamping _x/_y, and the widget's position
+    // is user-configurable via the display-edit screen. A widget placed with
+    // _x > 160 or _y > 240 wrote outside the 153,600-byte allocation.
+    const int startX = _x < 0 ? -_x : 0;
+    const int startY = _y < 0 ? -_y : 0;
+    const int endX   = min(MAP_W, SCREEN_WIDTH  - _x);
+    const int endY   = min(MAP_H, SCREEN_HEIGHT - _y);
 
-        // Destination row in the full-screen canvas.
-        uint16_t* dst = canvasBuf + (_y + row) * SCREEN_WIDTH + _x;
+    if (endX <= startX || endY <= startY) return;   // fully off-screen
 
-        memcpy(dst, src, MAP_W * sizeof(uint16_t));
+    const size_t rowBytes = (size_t)(endX - startX) * sizeof(uint16_t);
+
+    for (int row = startY; row < endY; ++row) {
+        const uint16_t* src = tilePixels + row * MAP_W + startX;
+        uint16_t* dst = canvasBuf + (_y + row) * SCREEN_WIDTH + (_x + startX);
+        memcpy(dst, src, rowBytes);
     }
 }
 

--- a/src/ui/Widgets/MapWidget.cpp
+++ b/src/ui/Widgets/MapWidget.cpp
@@ -291,15 +291,27 @@ void MapWidget::renderTrack() {
 // ---------------------------------------------------------------------------
 
 void MapWidget::project(double lat, double lon, int& outX, int& outY) const {
-    const double metersPerDegLat = 111132.0;
-    const double metersPerDegLon = 111320.0 * cos(_centerLat * M_PI / 180.0);
+    // Web Mercator, matching the projection the tiles are rendered in.
+    //
+    // This was previously an equirectangular approximation (flat degrees-to-
+    // metres constants) drawn over a Web Mercator raster. The two agree only
+    // near the centre of the viewport and only at low latitudes; away from
+    // either, the track drifted off the roads beneath it. Projecting both
+    // layers the same way removes the class of error rather than tuning it.
+    const double n = (double)(1u << _currentZoom);
+    const double worldPx = n * (double)TileLoader::TILE_SIZE;
 
-    double dxMeters = (lon - _centerLon) * metersPerDegLon;
-    double dyMeters = (lat - _centerLat) * metersPerDegLat;
+    auto lonToWorldX = [&](double l) {
+        return (l + 180.0) / 360.0 * worldPx;
+    };
+    auto latToWorldY = [&](double l) {
+        const double rad = l * M_PI / 180.0;
+        return (1.0 - log(tan(rad) + 1.0 / cos(rad)) / M_PI) / 2.0 * worldPx;
+    };
 
-    double cx = _x + (_width  / 2.0);
-    double cy = _y + (_height / 2.0);
+    const double cx = _x + (_width  / 2.0);
+    const double cy = _y + (_height / 2.0);
 
-    outX = (int)(cx + (dxMeters / _metersPerPixel));
-    outY = (int)(cy - (dyMeters / _metersPerPixel));
+    outX = (int)(cx + (lonToWorldX(lon) - lonToWorldX(_centerLon)));
+    outY = (int)(cy + (latToWorldY(lat) - latToWorldY(_centerLat)));
 }

--- a/src/ui/Widgets/MapWidget.hpp
+++ b/src/ui/Widgets/MapWidget.hpp
@@ -44,6 +44,9 @@ private:
     DataModel& _model;
     double _centerLat  = 0.0;
     double _centerLon  = 0.0;
+    // Requested scale. Only used to choose the integer zoom level; once that
+    // is chosen, both the tiles and the track overlay work in that level's
+    // Web Mercator world-pixel space, so nothing else reads this.
     float  _metersPerPixel = 4.0f;
     int    _currentZoom    = -1;   // cached, recomputed only when _metersPerPixel changes
     uint32_t _lastVersion  = 0;


### PR DESCRIPTION
Addresses **H8, H9** from #3. Two commits.

> Depends on #4 for the build.

## H9 — unbounded write into the framebuffer

```cpp
uint16_t* dst = canvasBuf + (_y + row) * SCREEN_WIDTH + _x;
memcpy(dst, src, MAP_W * sizeof(uint16_t));
```

Writing straight at the buffer bypasses the bounds checking in `Adafruit_GFX::drawPixel` that protects every other drawing path, and nothing clamped `_x` or `_y`. The widget is 80×80 on a 240×320 canvas, so any placement with `_x > 160` or `_y > 240` wrote outside the 153,600-byte allocation — **a heap overwrite driven by widget geometry, which is user-configurable through the display-edit screen.**

The sibling `TileLoader::loadRawTileToCanvas` already clamps before delegating; this path never got the same treatment.

Also returns early if `getBuffer()` is null — `GFXcanvas16`'s constructor does `if ((buffer = malloc(bytes))) { memset(...); }`, so on allocation failure it leaves `buffer` null and completes construction anyway, with nothing downstream checking. Separate concern, but it costs one line here.

## H8 — two different projections in the same widget

Tiles are Web Mercator at an integer zoom. `project()` used an **equirectangular** approximation:

```cpp
const double metersPerDegLat = 111132.0;
const double metersPerDegLon = 111320.0 * cos(_centerLat * M_PI/180.0);
outX = (int)(cx + (dxMeters / _metersPerPixel));
```

Two independent errors compounded:

1. `computeZoom` **rounds** to an integer zoom, so the raster's true resolution can differ from the requested `_metersPerPixel` by up to √2 — while `project()` kept using the requested value.
2. Even at a matching scale, the two projections agree only near the viewport centre and only at low latitudes.

Net effect: the track sat at the wrong scale relative to the roads beneath it and drifted further out toward the edges.

`project()` now converts through the same Web Mercator world-pixel space the tiles are indexed in, so the two layers share one projection **by construction** rather than by keeping two formulas in agreement.

`_metersPerPixel` survives only as the input to zoom selection — noted in the header so it isn't mistaken for a live scale factor. I initially added an `_effectiveMetersPerPixel` member to carry the corrected scale, then removed it once `project()` moved to world pixels and it became dead.

## Verification

`pio run` clean after each commit, no new warnings. Flash 420148 → 420524 bytes (+376, the Mercator transform).

**Not flashed to hardware, and this PR wants it more than most.** H8 is a visual change that's hard to argue from first principles alone — the right check is a ride with tiles on the SD card, confirming the breadcrumb trail now follows the roads rather than diverging from them toward the edges of the widget. H9 is behaviour-preserving for any widget that was already fully on-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)