### PR TITLE
[Draft] C1: stop BLE callbacks mutating state the main loop is iterating

### DIFF
--- a/src/HAL/Bluetooth/BluetoothSystem.cpp
+++ b/src/HAL/Bluetooth/BluetoothSystem.cpp
@@ -6,6 +6,9 @@ BluetoothSystem::DeviceListCallback BluetoothSystem::deviceListCallback;
 E_Type_BT_Mode BluetoothSystem::_mode, BluetoothSystem::_mode_prev;
 IStorage* BluetoothSystem::_storage;
 uint32_t BluetoothSystem::lastBatUpdate = millis() - 10000;
+SpscRing<BluetoothDevice, 8> BluetoothSystem::pendingDiscovered;
+SpscRing<MacAddress, 8> BluetoothSystem::pendingDisconnected;
+volatile bool BluetoothSystem::deviceListDirty = false;
 
 void BluetoothSystem::init(IStorage* storage) {
     deviceList.clear();
@@ -32,8 +35,55 @@ void BluetoothSystem::init(IStorage* storage) {
     Bluefruit.Scanner.setInterval(160, 80);  // in unit of 0.625 ms
 }
 
+void BluetoothSystem::drainPendingEvents() {
+    bool changed = false;
+
+    // Devices discovered by the scanner, queued from the BLE task.
+    BluetoothDevice found;
+    while (pendingDiscovered.pop(found)) {
+        bool known = false;
+        for (uint16_t i = 0; i < deviceList.size(); i++) {
+            if (deviceList[i].MAC == found.MAC) { known = true; break; }
+        }
+        // The duplicate check also happens in scan_discovery, but that one
+        // reads deviceList from the BLE task and can race with this function.
+        // Re-checking here is what actually guarantees uniqueness.
+        if (!known) {
+            Serial.print("New device found: "); Serial.println(found.name);
+            deviceList.push_back(found);
+            changed = true;
+        }
+    }
+
+    // Unexpected disconnects, queued from Bluefruit's disconnect callback.
+    MacAddress gone;
+    while (pendingDisconnected.pop(gone)) {
+        for (auto it = deviceList.begin(); it != deviceList.end(); it++) {
+            if ((*it).MAC == gone) {
+                (*it).connected = false;
+                Serial.println("device disconnected");
+                changed = true;
+                break;
+            }
+        }
+    }
+
+    if (deviceListDirty) {
+        deviceListDirty = false;
+        changed = true;
+    }
+
+    if (changed && deviceListCallback) {
+        deviceListCallback(deviceList);
+    }
+}
+
 void BluetoothSystem::update() {
-    
+
+    // Apply anything the BLE task queued since the last iteration, before
+    // touching deviceList below.
+    drainPendingEvents();
+
     switch (_mode) {
         case E_Type_BT_Mode::connect:
             if (_mode != _mode_prev) {
@@ -73,6 +123,7 @@ void BluetoothSystem::update() {
         (*it).connected = BT_Device::deviceWithMacDiscovered((*it).MAC);
         if ((*it).connected) {
             BT_Device* dev = BT_Device::getDeviceWithMAC((*it).MAC);
+            if (!dev) continue;   // discovered but no longer in btDevices
             (*it).batt = dev->readBatt();
             dev->update(now);
         }
@@ -90,10 +141,10 @@ void BluetoothSystem::connect_callback(uint16_t conn_handle) {
     if (device != NULL) {
         if(!device->discovered()) {
             Serial.println("Not discovered");
+            // discover() must run in this context -- it issues GATT reads --
+            // but the UI notification must not. Flag it for update() instead.
             device->discover(conn_handle);
-            if (deviceListCallback) {
-                deviceListCallback(deviceList);
-            }
+            deviceListDirty = true;
         }
     }
     if (!BT_Device::all_devices_discovered()) {
@@ -137,9 +188,9 @@ void BluetoothSystem::scan_discovery(ble_gap_evt_adv_report_t* report) {
             }
         }
     }
-    //if the new device is unique add it
+    //if the new device is unique queue it for the main loop to add
     if (!bMatch) {
-        
+
         if(Bluefruit.Scanner.checkReportForUuid(report, GATT_CSC_UUID))
             newDevice.type = E_Type_BT_Device::bt_csc;
         if(Bluefruit.Scanner.checkReportForUuid(report, UUID16_SVC_HEART_RATE))
@@ -147,12 +198,11 @@ void BluetoothSystem::scan_discovery(ble_gap_evt_adv_report_t* report) {
         if(Bluefruit.Scanner.checkReportForUuid(report, GATT_CPS_UUID))
             newDevice.type = E_Type_BT_Device::bt_cps;
 
-        Serial.print("New device found: "); Serial.println(newDevice.name);
-        deviceList.push_back(newDevice);
-        
-        if (deviceListCallback) {
-            deviceListCallback(deviceList);
-        }
+        // Runs on the SoftDevice task: enqueue only. push_back here could
+        // reallocate deviceList while update() is iterating it, and firing
+        // deviceListCallback from this context would run App/UI code --
+        // including a std::vector copy in BluetoothDataProvider -- off-thread.
+        pendingDiscovered.push(newDevice);
     }
 
     // For Softdevice v6: after received a report, scanner will be paused
@@ -204,16 +254,10 @@ void BluetoothSystem::disconnectDevice(const BluetoothDevice& device) {
 }
 
 void BluetoothSystem::onDeviceUnexpectedDisconnect(MacAddress MAC) {
-    for (auto it = deviceList.begin(); it != deviceList.end(); it++) {
-        if ((*it).MAC == MAC) {
-            (*it).connected = false;
-            break;
-        }
-    }
-    if (deviceListCallback) {
-        Serial.println("device disconnected");
-        deviceListCallback(deviceList);
-    }
+    // Invoked from BT_Device::disconnect, which runs in Bluefruit's
+    // disconnect callback -- i.e. on the BLE task. Queue it; update() marks
+    // the device disconnected and notifies the UI.
+    pendingDisconnected.push(MAC);
 }
 
 void BluetoothSystem::loadDevices() {

--- a/src/HAL/Bluetooth/BluetoothSystem.hpp
+++ b/src/HAL/Bluetooth/BluetoothSystem.hpp
@@ -12,6 +12,7 @@
 #include "cps.hpp"
 #include "HAL/BluetoothInterface.hpp"
 #include "HAL/StorageInterface.hpp"
+#include "SpscRing.hpp"
 
 /**
 * @class BluetoothSystem
@@ -94,6 +95,20 @@ class BluetoothSystem {
     static DeviceListCallback deviceListCallback;
     static IStorage* _storage;
     static uint32_t lastBatUpdate;
+
+    // --- BLE task -> main loop hand-off (see SpscRing.hpp) --------------
+    //
+    // Bluefruit dispatches scan/connect/disconnect callbacks from its own
+    // FreeRTOS task. Those callbacks used to push_back into deviceList and
+    // invoke deviceListCallback directly, while the main loop was iterating
+    // the same vector -- a reallocation mid-iteration is a use-after-free.
+    // They now only enqueue, and update() applies the changes.
+    static SpscRing<BluetoothDevice, 8> pendingDiscovered;
+    static SpscRing<MacAddress, 8> pendingDisconnected;
+    static volatile bool deviceListDirty;   // set by callbacks, cleared by update()
+
+    /** Applies queued BLE events to deviceList. Main loop only. */
+    static void drainPendingEvents();
 
 
     /**

--- a/src/HAL/Bluetooth/SpscRing.hpp
+++ b/src/HAL/Bluetooth/SpscRing.hpp
@@ -1,0 +1,77 @@
+#ifndef SPSCRING_H
+#define SPSCRING_H
+
+#include <Arduino.h>
+
+/**
+ * @class SpscRing
+ * @brief Fixed-capacity lock-free queue for handing data from one producer
+ *        thread to one consumer thread.
+ *
+ * Used to move BLE events off the SoftDevice callback task and onto the main
+ * loop. Bluefruit dispatches scan and notify callbacks from its own FreeRTOS
+ * task, so anything those callbacks touch is shared mutable state -- and a
+ * std::vector reallocating under an iterator held by the other task is a
+ * use-after-free, not merely a stale read.
+ *
+ * Correctness argument, since "lock-free" deserves one:
+ *
+ *  - Exactly one producer (the BLE task, calling push) and exactly one
+ *    consumer (the main loop, calling pop). This is not safe for multiple
+ *    producers.
+ *  - The producer only ever writes _tail; the consumer only ever writes
+ *    _head. Neither index is read-modify-written by both sides, so no
+ *    atomic RMW is required.
+ *  - Index loads and stores are single-byte and naturally aligned, so they
+ *    are atomic on Cortex-M.
+ *  - The __DMB() barriers order the slot write against the index publish
+ *    (and the slot read against the index release), which is what stops the
+ *    other side observing an index that points at a half-written slot.
+ *  - Storage is a fixed array, so push() performs no allocation. Calling
+ *    malloc from a SoftDevice callback is its own hazard.
+ *
+ * Capacity is N-1 entries: one slot is left empty so that full and empty
+ * are distinguishable without a separate count that both sides would write.
+ *
+ * push() returns false and drops the item when full. For discovery events
+ * that is the right behaviour -- losing one advertisement is harmless, the
+ * peripheral will advertise again -- but callers that cannot tolerate loss
+ * should check the return value.
+ */
+template <typename T, uint8_t N>
+class SpscRing {
+    static_assert(N >= 2, "SpscRing needs at least 2 slots");
+
+public:
+    /** Producer side. Safe to call from a BLE callback. */
+    bool push(const T& value) {
+        const uint8_t tail = _tail;
+        const uint8_t next = (uint8_t)((tail + 1) % N);
+        if (next == _head) return false;   // full -- drop rather than block
+
+        _buf[tail] = value;
+        __DMB();                            // publish the slot before the index
+        _tail = next;
+        return true;
+    }
+
+    /** Consumer side. Only call from the main loop. */
+    bool pop(T& out) {
+        const uint8_t head = _head;
+        if (head == _tail) return false;    // empty
+
+        out = _buf[head];
+        __DMB();                            // finish reading before releasing
+        _head = (uint8_t)((head + 1) % N);
+        return true;
+    }
+
+    bool empty() const { return _head == _tail; }
+
+private:
+    T _buf[N];
+    volatile uint8_t _head = 0;   // written by consumer only
+    volatile uint8_t _tail = 0;   // written by producer only
+};
+
+#endif /* SPSCRING_H */


### PR DESCRIPTION
Addresses **C1** from #3 — the last unfixed Critical. **Opened as a draft**: this is a design change rather than a patch, and it's the one fix in the series I genuinely cannot validate without hardware, since the failure mode is a race.

> Depends on #4 for the build. Conflicts with #6 (`fix/ble-safety`) — both touch `BluetoothSystem.cpp`. **Merge #6 first**; I'll rebase this on top.

## The problem

Bluefruit dispatches scan, connect and disconnect callbacks from its own FreeRTOS task, not from `loop()`. Three of them mutated state the main loop reads concurrently, with no synchronisation anywhere:

| Callback | Mutation |
|---|---|
| `scan_discovery` | `deviceList.push_back(newDevice)` |
| `onDeviceUnexpectedDisconnect` | `(*it).connected = false` |
| `connect_callback` | `deviceListCallback(deviceList)` |

…while `BluetoothSystem::update()` iterates that same vector. **A `push_back` that reallocates while the other task holds an iterator is a use-after-free**, not a stale read. This is my best candidate for unexplained hard faults during scanning.

`deviceListCallback` is worse than it first appears. It runs `App::updateBluetooth` → `BluetoothDataProvider::update`, which **copy-assigns a `std::vector`** — so a heap allocation and a full container copy were happening on the SoftDevice's task, triggered by an incoming advertisement.

## The change

Callbacks now only enqueue; `update()` applies changes and notifies the UI from the main loop.

- discovered devices → `SpscRing<BluetoothDevice, 8>`
- unexpected disconnects → `SpscRing<MacAddress, 8>`
- `connect_callback` sets a dirty flag. `discover()` stays in that context — it issues GATT reads and has to.

`SpscRing` is a fixed-capacity lock-free queue for exactly one producer and one consumer. I wrote the correctness argument into the header rather than leaving "lock-free" as an assertion: separate index ownership (producer only writes `_tail`, consumer only writes `_head`, so no atomic RMW is needed), single-byte naturally-aligned indices are atomic on Cortex-M, and `__DMB()` orders the slot write against the index publish. Storage is a plain array so `push()` doesn't allocate — calling `malloc` from a SoftDevice callback is its own hazard.

Discovery duplicate-checking **moves to the consumer**. The check in `scan_discovery` reads `deviceList` from the BLE task and can itself race, so it's now advisory; the one in `drainPendingEvents` is what actually guarantees uniqueness.

Also guards the `getDeviceWithMAC` result in `update()`, which was dereferenced unchecked.

## Scope — what this does NOT fix

The per-device scalars written by `csc`/`cps`/`hrm` notify handlers and read by `getSpeed`/`getCadence`/`getPower` are **still unsynchronised**. That's a torn or stale read of a `float` rather than heap corruption — a correctness wart, not a crash — and fixing it properly means double-buffering each profile's measurement block. Left for a follow-up so this change stays reviewable.

Being explicit because it matters: **this PR does not make the BLE layer thread-safe. It removes the memory-corruption class specifically.**

## Why draft

Races don't show up in a build, and a clean `pio run` says nothing about whether I got the hand-off right. What I'd want before this merges:

1. Your read on the design — a FreeRTOS mutex around `deviceList` would also work and is more conventional; I chose the queue because it keeps allocation and UI work off the BLE task entirely, not just serialised with it.
2. On-device soak: scan with several sensors advertising, repeatedly enter/leave the Bluetooth screen, power-cycle a sensor mid-scan. The old code should be reproducibly unstable under that; the new code shouldn't.

Queue depth of 8 is a guess. If discovery events can burst faster than one main-loop iteration, pushes get dropped — harmless for advertisements, which repeat, but worth knowing.

## Verification

`pio run` clean. Flash 420148 → 420892 bytes (+744).

🤖 Generated with [Claude Code](https://claude.com/claude-code)